### PR TITLE
#1 Environment Resource

### DIFF
--- a/skytap/datasource_skytap_project_test.go
+++ b/skytap/datasource_skytap_project_test.go
@@ -19,11 +19,11 @@ func TestAccDataSourceSkytapProject_Basic(t *testing.T) {
 			{
 				Config: testAccDataSourceSkytapProjectConfig_basic(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckSkytapProjectExists("data.skytap_project.foo"),
-					resource.TestCheckResourceAttr("data.skytap_project.foo", "name", fmt.Sprintf("tftest-project-%d", rInt)),
-					resource.TestCheckResourceAttrSet("data.skytap_project.foo", "summary"),
-					resource.TestCheckResourceAttr("data.skytap_project.foo", "auto_add_role_name", ""),
-					resource.TestCheckResourceAttr("data.skytap_project.foo", "show_project_members", "true"),
+					testAccCheckSkytapProjectExists("data.skytap_project.bar"),
+					resource.TestCheckResourceAttr("data.skytap_project.bar", "name", fmt.Sprintf("tftest-project-data-%d", rInt)),
+					resource.TestCheckResourceAttrSet("data.skytap_project.bar", "summary"),
+					resource.TestCheckResourceAttr("data.skytap_project.bar", "auto_add_role_name", ""),
+					resource.TestCheckResourceAttr("data.skytap_project.bar", "show_project_members", "true"),
 				),
 			},
 		},
@@ -33,11 +33,11 @@ func TestAccDataSourceSkytapProject_Basic(t *testing.T) {
 func testAccDataSourceSkytapProjectConfig_basic(rInt int) string {
 	return fmt.Sprintf(`
 resource "skytap_project" "foo" {
-	name = "tftest-project-%d"
+	name = "tftest-project-data-%d"
 	summary = "This is a project created by the skytap terraform provider acceptance test"
 }
 
-data "skytap_project" "foo" {
+data "skytap_project" "bar" {
 	name = "${skytap_project.foo.name}"
 }`, rInt)
 }

--- a/skytap/provider.go
+++ b/skytap/provider.go
@@ -34,7 +34,8 @@ func Provider() terraform.ResourceProvider {
 		},
 
 		ResourcesMap: map[string]*schema.Resource{
-			"skytap_project": resourceSkytapProject(),
+			"skytap_project":     resourceSkytapProject(),
+			"skytap_environment": resourceSkytapEnvironment(),
 		},
 	}
 

--- a/skytap/resource_skytap_environment.go
+++ b/skytap/resource_skytap_environment.go
@@ -1,0 +1,248 @@
+package skytap
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
+	"github.com/pkg/errors"
+	"github.com/skytap/skytap-sdk-go/skytap"
+	"github.com/skytap/terraform-provider-skytap/skytap/utils"
+	"log"
+)
+
+func resourceSkytapEnvironment() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceSkytapEnvironmentCreate,
+		Read:   resourceSkytapEnvironmentRead,
+		Update: resourceSkytapEnvironmentUpdate,
+		Delete: resourceSkytapEnvironmentDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"template_id": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.NoZeroValues,
+			},
+
+			"project_id": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.NoZeroValues,
+			},
+
+			"name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.NoZeroValues,
+			},
+
+			"description": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.NoZeroValues,
+			},
+
+			//"owner": {
+			//	Type:         schema.TypeString,
+			//	Optional:     true,
+			//	ValidateFunc: validation.NoZeroValues,
+			//},
+
+			"outbound_traffic": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+
+			"routable": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+
+			"suspend_on_idle": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Default:  nil,
+			},
+
+			"suspend_at_time": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  nil,
+			},
+
+			"shutdown_on_idle": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Default:  nil,
+			},
+
+			"shutdown_at_time": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  nil,
+			},
+		},
+	}
+}
+
+func resourceSkytapEnvironmentCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*SkytapClient).environmentsClient
+	ctx := meta.(*SkytapClient).StopContext
+
+	log.Printf("[INFO] preparing arguments for creating the SkyTap Environment")
+
+	templateId := d.Get("template_id").(string)
+	name := d.Get("name").(string)
+	outboundTraffic := d.Get("outbound_traffic").(bool)
+	routable := d.Get("routable").(bool)
+
+	opts := skytap.CreateEnvironmentRequest{
+		TemplateId:      &templateId,
+		Name:            &name,
+		OutboundTraffic: &outboundTraffic,
+		Routable:        &routable,
+	}
+
+	if v, ok := d.GetOk("project_id"); ok {
+		opts.ProjectId = utils.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("description"); ok {
+		opts.Description = utils.String(v.(string))
+	}
+
+	//if v, ok := d.GetOk("owner"); ok {
+	//	opts.Owner = utils.String(v.(string))
+	//}
+
+	if v, ok := d.GetOk("suspend_on_idle"); ok {
+		opts.SuspendOnIdle = utils.Int(v.(int))
+	}
+
+	if v, ok := d.GetOk("suspend_at_time"); ok {
+		opts.SuspendAtTime = utils.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("shutdown_on_idle"); ok {
+		opts.ShutdownOnIdle = utils.Int(v.(int))
+	}
+
+	if v, ok := d.GetOk("shutdown_at_time"); ok {
+		opts.ShutdownAtTime = utils.String(v.(string))
+	}
+
+	log.Printf("[DEBUG] environment create options: %#v", opts)
+	environment, err := client.Create(ctx, &opts)
+	if err != nil {
+		return errors.Errorf("error creating environment: %v", err)
+	}
+
+	d.SetId(*environment.ID)
+
+	return resourceSkytapEnvironmentRead(d, meta)
+}
+
+func resourceSkytapEnvironmentRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*SkytapClient).environmentsClient
+	ctx := meta.(*SkytapClient).StopContext
+
+	id := d.Id()
+
+	log.Printf("[INFO] retrieving environment: %s", id)
+	environment, err := client.Get(ctx, id)
+	if err != nil {
+		if utils.ResponseErrorIsNotFound(err) {
+			log.Printf("[DEBUG] environment (%s) was not found - removing from state", id)
+			d.SetId("")
+			return nil
+		}
+
+		return fmt.Errorf("error retrieving environment (%s): %v", id, err)
+	}
+
+	d.Set("name", environment.Name)
+	d.Set("description", environment.Description)
+	//d.Set("owner", environment.OwnerID)
+	d.Set("outbound_traffic", environment.OutboundTraffic)
+	d.Set("routable", environment.OutboundTraffic)
+	d.Set("suspend_on_idle", environment.SuspendOnIdle)
+	d.Set("suspend_at_time", environment.SuspendAtTime)
+	d.Set("shutdown_on_idle", environment.ShutdownOnIdle)
+	d.Set("shutdown_at_time", environment.ShutdownAtTime)
+
+	return err
+}
+
+func resourceSkytapEnvironmentUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*SkytapClient).environmentsClient
+	ctx := meta.(*SkytapClient).StopContext
+
+	id := d.Id()
+
+	name := d.Get("name").(string)
+	outboundTraffic := d.Get("outbound_traffic").(bool)
+	routable := d.Get("routable").(bool)
+
+	opts := skytap.UpdateEnvironmentRequest{
+		Name:            &name,
+		OutboundTraffic: &outboundTraffic,
+		Routable:        &routable,
+	}
+
+	if v, ok := d.GetOk("description"); ok {
+		opts.Description = utils.String(v.(string))
+	}
+
+	//if v, ok := d.GetOk("owner"); ok {
+	//	opts.Owner = utils.String(v.(string))
+	//}
+
+	if v, ok := d.GetOk("suspend_on_idle"); ok {
+		opts.SuspendOnIdle = utils.Int(v.(int))
+	}
+
+	if v, ok := d.GetOk("suspend_at_time"); ok {
+		opts.SuspendAtTime = utils.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("shutdown_on_idle"); ok {
+		opts.ShutdownOnIdle = utils.Int(v.(int))
+	}
+
+	if v, ok := d.GetOk("shutdown_at_time"); ok {
+		opts.ShutdownAtTime = utils.String(v.(string))
+	}
+
+	log.Printf("[DEBUG] environment update options: %#v", opts)
+	_, err := client.Update(ctx, id, &opts)
+	if err != nil {
+		return errors.Errorf("error updating environment (%s): %v", id, err)
+	}
+
+	return resourceSkytapEnvironmentRead(d, meta)
+}
+
+func resourceSkytapEnvironmentDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*SkytapClient).environmentsClient
+	ctx := meta.(*SkytapClient).StopContext
+
+	id := d.Id()
+
+	log.Printf("[INFO] destroying environment: %s", id)
+	err := client.Delete(ctx, id)
+	if err != nil {
+		if utils.ResponseErrorIsNotFound(err) {
+			log.Printf("[DEBUG] environment (%s) was not found - assuming removed", id)
+			return nil
+		}
+
+		return fmt.Errorf("error deleting environment (%s): %v", id, err)
+	}
+
+	return err
+}

--- a/skytap/resource_skytap_environment_test.go
+++ b/skytap/resource_skytap_environment_test.go
@@ -1,0 +1,142 @@
+package skytap
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/pkg/errors"
+	"github.com/skytap/terraform-provider-skytap/skytap/utils"
+	"log"
+	"testing"
+)
+
+func init() {
+	resource.AddTestSweepers("skytap_environment", &resource.Sweeper{
+		Name: "skytap_environment",
+		F:    testSweepSkytapEnvironment,
+	})
+}
+
+func testSweepSkytapEnvironment(region string) error {
+	meta, err := sharedClientForRegion(region)
+	if err != nil {
+		return err
+	}
+
+	client := meta.environmentsClient
+	ctx := meta.StopContext
+
+	log.Printf("[INFO] Retrieving list of environments")
+	environments, err := client.List(ctx)
+	if err != nil {
+		return fmt.Errorf("error retrieving list of environments: %v", err)
+	}
+
+	for _, e := range environments.Value {
+		if shouldSweepAcceptanceTestResource(*e.Name) {
+			log.Printf("destroying environment %s", *e.Name)
+			if err := client.Delete(ctx, *e.ID); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func TestAccSkytapEnvironment_Basic(t *testing.T) {
+	rInt := acctest.RandInt()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckSkytapEnvironmentDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSkytapEnvironmentConfig_basic(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSkytapEnvironmentExists("skytap_environment.foo"),
+					resource.TestCheckResourceAttr("skytap_environment.foo", "name", fmt.Sprintf("tftest-environment-%d", rInt)),
+					resource.TestCheckResourceAttrSet("skytap_environment.foo", "description"),
+					resource.TestCheckResourceAttrSet("skytap_environment.foo", "template_id"),
+					resource.TestCheckNoResourceAttr("skytap_environment.foo", "project_id"),
+					resource.TestCheckResourceAttr("skytap_environment.foo", "outbound_traffic", "false"),
+					resource.TestCheckResourceAttr("skytap_environment.foo", "routable", "false"),
+					resource.TestCheckResourceAttr("skytap_environment.foo", "suspend_on_idle", "0"),
+					resource.TestCheckResourceAttr("skytap_environment.foo", "suspend_at_time", ""),
+					resource.TestCheckResourceAttr("skytap_environment.foo", "shutdown_on_idle", "0"),
+					resource.TestCheckResourceAttr("skytap_environment.foo", "shutdown_at_time", ""),
+				),
+			},
+		},
+	})
+}
+
+// Verifies the Environment exists
+func testAccCheckSkytapEnvironmentExists(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("not found: %q", name)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("no Environment ID is set")
+		}
+
+		// retrieve the connection established in Provider configuration
+		client := testAccProvider.Meta().(*SkytapClient).environmentsClient
+		ctx := testAccProvider.Meta().(*SkytapClient).StopContext
+
+		// Retrieve our environment by referencing it's state ID for API lookup
+		_, err := client.Get(ctx, rs.Primary.ID)
+		if err != nil {
+			if utils.ResponseErrorIsNotFound(err) {
+				return errors.Errorf("environment (%s) was not found - does not exist", rs.Primary.ID)
+			}
+
+			return fmt.Errorf("error retrieving environment (%s): %v", rs.Primary.ID, err)
+		}
+
+		return nil
+	}
+}
+
+// Verifies the Environment has been destroyed
+func testAccCheckSkytapEnvironmentDestroy(s *terraform.State) error {
+	// retrieve the connection established in Provider configuration
+	client := testAccProvider.Meta().(*SkytapClient).environmentsClient
+	ctx := testAccProvider.Meta().(*SkytapClient).StopContext
+
+	// loop through the resources in state, verifying each environment
+	// is destroyed
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "skytap_environment" {
+			continue
+		}
+
+		// Retrieve our environment by referencing it's state ID for API lookup
+		_, err := client.Get(ctx, rs.Primary.ID)
+		if err != nil {
+			if utils.ResponseErrorIsNotFound(err) {
+				return nil
+			}
+
+			return fmt.Errorf("error waiting for environment (%s) to be destroyed: %s", rs.Primary.ID, err)
+		}
+
+		return fmt.Errorf("environment still exists: %s", rs.Primary.ID)
+	}
+
+	return nil
+}
+
+func testAccSkytapEnvironmentConfig_basic(rInt int) string {
+	return fmt.Sprintf(`
+resource "skytap_environment" "foo" {
+	template_id = "1452333"
+	name = "tftest-environment-%d"
+	description = "This is an environment created by the skytap terraform provider acceptance test"
+}`, rInt)
+}

--- a/vendor/github.com/skytap/skytap-sdk-go/skytap/environment.go
+++ b/vendor/github.com/skytap/skytap-sdk-go/skytap/environment.go
@@ -71,6 +71,7 @@ type Environment struct {
 	ScheduleCount           *int                 `json:"schedule_count"`
 	VpnCount                *int                 `json:"vpn_count"`
 	OutboundTraffic         *bool                `json:"outbound_traffic"`
+	Routable                *bool                `json:"routable"`
 	Vms                     []Vm                 `json:"vms"`
 	Networks                []Network            `json:"networks"`
 	ContainersCount         *int                 `json:"containers_count"`
@@ -108,8 +109,8 @@ type Vm struct {
 	Runstate               *VmRunstate  `json:"runstate"`
 	RateLimited            *bool        `json:"rate_limited"`
 	Hardware               *Hardware    `json:"hardware"`
-	Error                  *string      `json:"error"`
-	ErrorDetails           []string     `json:"error_details"`
+	Error                  *bool        `json:"error"`
+	ErrorDetails           *bool        `json:"error_details"`
 	AssetID                *string      `json:"asset_id"`
 	HardwareVersion        *int         `json:"hardware_version"`
 	MaxHardwareVersion     *int         `json:"max_hardware_version"`
@@ -343,7 +344,7 @@ type CreateEnvironmentRequest struct {
 	ProjectId       *string `json:"project_id,omitempty"`
 	Name            *string `json:"name,omitempty"`
 	Description     *string `json:"description,omitempty"`
-	Owner           *int    `json:"owner,omitempty"`
+	Owner           *string `json:"owner,omitempty"`
 	OutboundTraffic *bool   `json:"outbound_traffic,omitempty"`
 	Routable        *bool   `json:"routable,omitempty"`
 	SuspendOnIdle   *int    `json:"suspend_on_idle,omitempty"`
@@ -355,7 +356,7 @@ type CreateEnvironmentRequest struct {
 type UpdateEnvironmentRequest struct {
 	Name            *string `json:"name,omitempty"`
 	Description     *string `json:"description,omitempty"`
-	Owner           *int    `json:"owner,omitempty"`
+	Owner           *string `json:"owner,omitempty"`
 	OutboundTraffic *bool   `json:"outbound_traffic,omitempty"`
 	Routable        *bool   `json:"routable,omitempty"`
 	SuspendOnIdle   *int    `json:"suspend_on_idle,omitempty"`
@@ -366,6 +367,11 @@ type UpdateEnvironmentRequest struct {
 
 func (s *EnvironmentsServiceClient) List(ctx context.Context) (*EnvironmentListResult, error) {
 	req, err := s.client.newRequest(ctx, "GET", environmentBasePath, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	err = s.client.setRequestListParameters(req, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -394,10 +400,6 @@ func (s *EnvironmentsServiceClient) Get(ctx context.Context, id string) (*Enviro
 	}
 
 	return &environment, nil
-}
-
-func stringValueAsPtr(v string) *string {
-	return &v
 }
 
 func (s *EnvironmentsServiceClient) Create(ctx context.Context, request *CreateEnvironmentRequest) (*Environment, error) {
@@ -451,7 +453,7 @@ func (s *EnvironmentsServiceClient) Update(ctx context.Context, id string, updat
 }
 
 func (s *EnvironmentsServiceClient) Delete(ctx context.Context, id string) error {
-	path := fmt.Sprintf("%s/%s", environmentBasePath, id)
+	path := fmt.Sprintf("%s/%s", environmentLegacyBasePath, id)
 
 	req, err := s.client.newRequest(ctx, "DELETE", path, nil)
 	if err != nil {

--- a/vendor/github.com/skytap/skytap-sdk-go/skytap/settings.go
+++ b/vendor/github.com/skytap/skytap-sdk-go/skytap/settings.go
@@ -18,13 +18,13 @@ type Settings struct {
 
 func (s *Settings) Validate() error {
 	if s.baseUrl == "" {
-		return fmt.Errorf("The base URL must be provided")
+		return fmt.Errorf("the base URL must be provided")
 	}
 	if s.userAgent == "" {
-		return fmt.Errorf("The user agent must be provided")
+		return fmt.Errorf("the user agent must be provided")
 	}
 	if s.credentials == nil {
-		return fmt.Errorf("The credential provider must be provided")
+		return fmt.Errorf("the credential provider must be provided")
 	}
 
 	return nil

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -757,10 +757,13 @@
 			"revisionTime": "2018-09-10T08:07:58Z"
 		},
 		{
-			"checksumSHA1": "tfggqcY1X3jBTT18foDy7YDGVMY=",
+			"checksumSHA1": "TeohhUi9zDsXXV9gauvF/UX4nL0=",
+			"origin": "github.com/opencredo/skytap-sdk-go/skytap",
 			"path": "github.com/skytap/skytap-sdk-go/skytap",
-			"revision": "80a2ede41fdd36aadc9aa6149fd8eac0bbab0568",
-			"revisionTime": "2018-10-15T01:14:38Z"
+			"revision": "6b148d9c4e108bbcd1d5c9276522097871bf4dde",
+			"revisionTime": "2018-10-16T12:52:41Z",
+			"version": "v2",
+			"versionExact": "v2"
 		},
 		{
 			"checksumSHA1": "c6pbpF7eowwO59phRTpF8cQ80Z0=",


### PR DESCRIPTION
Support for environment resource. Using a hardcoded template id for now. This will be replaced with a data source allowing the user to retrieve a template via its name.  

Test with terraform:
```
provider "skytap" {}

resource "skytap_environment" "foo" {
	template_id = "1452333"
	name = "manual test environment update"
	description = "This is an environment created to manually test the provider"
}
```