### PR TITLE
#25 Making description mandatory

### DIFF
--- a/skytap/resource_skytap_environment.go
+++ b/skytap/resource_skytap_environment.go
@@ -41,7 +41,7 @@ func resourceSkytapEnvironment() *schema.Resource {
 
 			"description": {
 				Type:         schema.TypeString,
-				Optional:     true,
+				Required:     true,
 				ValidateFunc: validation.NoZeroValues,
 			},
 


### PR DESCRIPTION
To ensure idempotency we need to ensure the description field is set by the terraform user.