### PR TITLE
#41 Improving the create, update and delete logic

### DIFF
--- a/skytap/resource_skytap_vm_test.go
+++ b/skytap/resource_skytap_vm_test.go
@@ -149,14 +149,14 @@ func testAccSkytapVMConfig_basic(envTemplateID string, uniqueSuffixEnv int, VMTe
 	return config
 }
 
-func getVM(rs *terraform.ResourceState, environmentId string) (*skytap.VM, error) {
+func getVM(rs *terraform.ResourceState, environmentID string) (*skytap.VM, error) {
 	var err error
 	// retrieve the connection established in Provider configuration
 	client := testAccProvider.Meta().(*SkytapClient).vmsClient
 	ctx := testAccProvider.Meta().(*SkytapClient).StopContext
 
 	// Retrieve our vm by referencing it's state ID for API lookup
-	vm, errClient := client.Get(ctx, environmentId, rs.Primary.ID)
+	vm, errClient := client.Get(ctx, environmentID, rs.Primary.ID)
 	if errClient != nil {
 		if utils.ResponseErrorIsNotFound(err) {
 			err = errors.Errorf("vm (%s) was not found - does not exist", rs.Primary.ID)

--- a/skytap/resource_skytap_vm_test.go
+++ b/skytap/resource_skytap_vm_test.go
@@ -63,11 +63,11 @@ func TestAccSkytapVM_Basic(t *testing.T) {
 		CheckDestroy: testAccCheckSkytapEnvironmentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSkytapVMConfig_basic(testEnvTemplateID, uniqueSuffixEnv, testVMTemplateID, testVMID, ""),
+				Config: testAccSkytapVMConfig_basic(testEnvTemplateID, uniqueSuffixEnv, testVMTemplateID, testVMID, "name = \"test\""),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSkytapVMExists("skytap_environment.foo", "skytap_vm.bar", &vm),
-					resource.TestCheckResourceAttr("skytap_vm.bar", "name", "CentOS 6 Desktop x64"),
-					resource.TestCheckResourceAttr("skytap_vm.bar", "runstate", string(skytap.VMRunstateRunning)),
+					resource.TestCheckResourceAttr("skytap_vm.bar", "name", "test"),
+					testAccCheckSkytapVMRunning(&vm),
 				),
 			},
 		},
@@ -89,6 +89,7 @@ func TestAccSkytapVM_Update(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSkytapVMExists("skytap_environment.foo", "skytap_vm.bar", &vm),
 					resource.TestCheckResourceAttr("skytap_vm.bar", "name", "CentOS 6 Desktop x64"),
+					testAccCheckSkytapVMRunning(&vm),
 				),
 			},
 			{
@@ -96,6 +97,7 @@ func TestAccSkytapVM_Update(t *testing.T) {
 					fmt.Sprintf("name = \"tftest-vm-%d\"", uniqueSuffixVM)),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("skytap_vm.bar", "name", fmt.Sprintf("tftest-vm-%d", uniqueSuffixVM)),
+					testAccCheckSkytapVMRunning(&vm),
 				),
 			},
 		},
@@ -163,4 +165,14 @@ func getVM(rs *terraform.ResourceState, environmentId string) (*skytap.VM, error
 		err = fmt.Errorf("error retrieving vm (%s): %v", rs.Primary.ID, err)
 	}
 	return vm, err
+}
+
+func testAccCheckSkytapVMRunning(vm *skytap.VM) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		resource.TestCheckResourceAttr("skytap_vm.bar", "runstate", string(skytap.VMRunstateRunning))
+		if skytap.VMRunstateRunning != *vm.Runstate {
+			return errors.Errorf("vm (%s) is not running as expected", *vm.ID)
+		}
+		return nil
+	}
 }

--- a/vendor/github.com/skytap/skytap-sdk-go/skytap/vm.go
+++ b/vendor/github.com/skytap/skytap-sdk-go/skytap/vm.go
@@ -218,6 +218,12 @@ const (
 
 // CreateVMRequest describes the create the VM data
 type CreateVMRequest struct {
+	TemplateID string
+	VMID       string
+}
+
+// createVMRequestAPI describes the create the VM data accepted by the API
+type createVMRequestAPI struct {
 	TemplateID string   `json:"template_id"`
 	VMID       []string `json:"vm_ids"`
 }
@@ -278,7 +284,12 @@ func (s *VMsServiceClient) Get(ctx context.Context, environmentID string, id str
 func (s *VMsServiceClient) Create(ctx context.Context, environmentID string, opts *CreateVMRequest) (*VM, error) {
 	path := s.buildPath(true, environmentID, "")
 
-	req, err := s.client.newRequest(ctx, "PUT", path, opts)
+	apiOpts := createVMRequestAPI{
+		TemplateID: opts.TemplateID,
+		VMID:       []string{opts.VMID},
+	}
+
+	req, err := s.client.newRequest(ctx, "PUT", path, apiOpts)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -757,10 +757,10 @@
 			"revisionTime": "2018-09-10T08:07:58Z"
 		},
 		{
-			"checksumSHA1": "EgOH2evQdo5B7jcnp5O8H88zpH4=",
+			"checksumSHA1": "JAdJpeX81CTibbQ1KS1gjidggg4=",
 			"path": "github.com/skytap/skytap-sdk-go/skytap",
-			"revision": "ae5600ada48c26130ef025a22a286021e56f3cf8",
-			"revisionTime": "2018-10-29T15:45:52Z",
+			"revision": "a29cefe3e8e452c79a89ad30dcd0e8ea7d74d20d",
+			"revisionTime": "2018-10-30T09:52:46Z",
 			"version": "v2",
 			"versionExact": "v2"
 		},

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -757,10 +757,10 @@
 			"revisionTime": "2018-09-10T08:07:58Z"
 		},
 		{
-			"checksumSHA1": "JAdJpeX81CTibbQ1KS1gjidggg4=",
+			"checksumSHA1": "mqRiILLz6XYX7ydoSMauyuvaKMs=",
 			"path": "github.com/skytap/skytap-sdk-go/skytap",
-			"revision": "a29cefe3e8e452c79a89ad30dcd0e8ea7d74d20d",
-			"revisionTime": "2018-10-30T09:52:46Z",
+			"revision": "adcba949c6d99acddf442b847050934f13b54374",
+			"revisionTime": "2018-10-30T12:44:15Z",
 			"version": "v2",
 			"versionExact": "v2"
 		},


### PR DESCRIPTION
1) the create function calls the SDK and logic now waits until VM is in `stopped` state before continuing.
2) the create function calls the update function to update the name (if necessary) and start the VM.
  2.1) the update function has a mode only used by create - whereby it changes the `runstate` to `running`.
3) the delete function waits until the resource has gone before completing.