### PR TITLE
Add attributes providing access to maps of computed VM resource settings

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,5 +1,6 @@
 TEST?=$$(go list ./... |grep -v 'vendor')
 GOFMT_FILES?=$$(find . -name '*.go' |grep -v vendor)
+GOIMPORT_FILES?=$$(find . -type f -name '*.go' -not -path './vendor/*')
 WEBSITE_REPO=github.com/hashicorp/terraform-website
 PKG_NAME=skytap
 
@@ -62,5 +63,8 @@ endif
 lint:
 	golint ./skytap/...
 
-.PHONY: build test testacc vet fmt fmtcheck errcheck vendor-status test-compile website website-test lint
+imports:
+	goimports -w $(GOIMPORT_FILES)
+
+.PHONY: build test testacc vet fmt fmtcheck errcheck vendor-status test-compile website website-test lint imports
 

--- a/skytap/resource_skytap_environment.go
+++ b/skytap/resource_skytap_environment.go
@@ -2,10 +2,10 @@ package skytap
 
 import (
 	"fmt"
-	"github.com/davecgh/go-spew/spew"
 	"log"
 	"time"
 
+	"github.com/davecgh/go-spew/spew"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/helper/validation"

--- a/skytap/resource_skytap_project.go
+++ b/skytap/resource_skytap_project.go
@@ -2,10 +2,10 @@ package skytap
 
 import (
 	"fmt"
-	"github.com/davecgh/go-spew/spew"
 	"log"
 	"strconv"
 
+	"github.com/davecgh/go-spew/spew"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/helper/validation"
 	"github.com/skytap/skytap-sdk-go/skytap"

--- a/skytap/resource_skytap_vm.go
+++ b/skytap/resource_skytap_vm.go
@@ -123,7 +123,7 @@ func resourceSkytapVM() *schema.Resource {
 			"external_ports": {
 				Type:     schema.TypeMap,
 				Computed: true,
-				Elem:     &schema.Schema{Type: schema.TypeInt},
+				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 		},
 	}

--- a/skytap/resource_skytap_vm.go
+++ b/skytap/resource_skytap_vm.go
@@ -3,11 +3,11 @@ package skytap
 import (
 	"bytes"
 	"fmt"
-	"github.com/davecgh/go-spew/spew"
-	"github.com/hashicorp/terraform/helper/hashcode"
 	"log"
 	"time"
 
+	"github.com/davecgh/go-spew/spew"
+	"github.com/hashicorp/terraform/helper/hashcode"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/helper/validation"
@@ -114,6 +114,11 @@ func resourceSkytapVM() *schema.Resource {
 						},
 					},
 				},
+			},
+			"external_ports": {
+				Type:     schema.TypeMap,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeInt},
 			},
 		},
 	}
@@ -322,12 +327,16 @@ func resourceSkytapVMRead(d *schema.ResourceData, meta interface{}) error {
 	// If any of these attributes are changed, this VM will be rebuilt.
 	d.Set("environment_id", environmentID)
 	d.Set("name", vm.Name)
+	externalPortMap := make(map[string]interface{})
 	if len(vm.Interfaces) > 0 {
-		if err := d.Set("network_interface", flattenNetworkInterfaces(vm.Interfaces)); err != nil {
+		if err := d.Set("network_interface", flattenNetworkInterfaces(vm.Interfaces, externalPortMap)); err != nil {
 			log.Printf("[ERROR] error flattening network interfaces: %v", err)
 			return err
 		}
 	}
+
+	d.Set("external_ports", externalPortMap)
+
 	log.Printf("[INFO] retrieved VM: %#v", spew.Sdump(vm))
 
 	return nil

--- a/skytap/resource_skytap_vm.go
+++ b/skytap/resource_skytap_vm.go
@@ -123,7 +123,7 @@ func resourceSkytapVM() *schema.Resource {
 			"external_ports": {
 				Type:     schema.TypeMap,
 				Computed: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
+				Elem:     &schema.Schema{Type: schema.TypeInt},
 			},
 		},
 	}
@@ -334,13 +334,13 @@ func resourceSkytapVMRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("name", vm.Name)
 
 	if len(vm.Interfaces) > 0 {
-		var ipMaps = []map[string]interface{}{make(map[string]interface{}), make(map[string]interface{})}
-		if err := d.Set("network_interface", flattenNetworkInterfaces(vm.Interfaces, ipMaps)); err != nil {
+		var publishedServices = []map[string]interface{}{make(map[string]interface{}), make(map[string]interface{})}
+		if err := d.Set("network_interface", flattenNetworkInterfaces(vm.Interfaces, publishedServices)); err != nil {
 			log.Printf("[ERROR] error flattening network interfaces: %v", err)
 			return err
 		}
-		d.Set("external_ips", ipMaps[0])
-		d.Set("external_ports", ipMaps[1])
+		d.Set("external_ips", publishedServices[0])
+		d.Set("external_ports", publishedServices[1])
 	}
 
 	log.Printf("[INFO] retrieved VM: %#v", spew.Sdump(vm))

--- a/skytap/resource_skytap_vm.go
+++ b/skytap/resource_skytap_vm.go
@@ -173,7 +173,7 @@ func resourceSkytapVMCreate(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
-	return updateVMResource(d, meta, false)
+	return updateVMResource(d, meta, true)
 }
 
 func waitForVMStopped(d *schema.ResourceData, meta interface{}) error {

--- a/skytap/resource_skytap_vm_test.go
+++ b/skytap/resource_skytap_vm_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 	"github.com/skytap/skytap-sdk-go/skytap"
+	"github.com/stretchr/testify/assert"
 	"github.com/terraform-providers/terraform-provider-skytap/skytap/utils"
 )
 
@@ -455,20 +456,6 @@ func TestAccExternalPorts(t *testing.T) {
 		},
 	})
 }
-func testAccCheckSkytapExternalPorts(t *testing.T, vmName string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		//rsVM, err := getResource(s, vmName)
-		//if err != nil {
-		//	return err
-		//}
-		//portMap, ok := rsVM.Primary.Attributes["external_ports"].(map[string]interface{})
-		//assert.True(t, ok)
-		//assert.NotEmpty(t, portMap["10-0-3-2_22"], "empty map entry")
-		//assert.NotEmpty(t, portMap["10-0-3-2_80"], "empty map entry")
-		return nil
-	}
-}
-
 func testAccSkytapVMConfig_cassandra(templateID string, vmID string, uniqueSuffixEnv int, existingPort int, extraPublishedService string, extraNIC string) string {
 	config := fmt.Sprintf(`
 
@@ -703,6 +690,18 @@ func testAccCheckSkytapVMRunning(vm *skytap.VM) resource.TestCheckFunc {
 		if skytap.VMRunstateRunning != *vm.Runstate {
 			return fmt.Errorf("vm (%s) is not running as expected", *vm.ID)
 		}
+		return nil
+	}
+}
+
+func testAccCheckSkytapExternalPorts(t *testing.T, vmName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rsVM, err := getResource(s, vmName)
+		if err != nil {
+			return err
+		}
+		assert.Equal(t, "4", rsVM.Primary.Attributes["external_ips.%"], "empty map entry")
+		assert.Equal(t, "4", rsVM.Primary.Attributes["external_ports.%"], "empty map entry")
 		return nil
 	}
 }

--- a/skytap/resource_skytap_vm_test.go
+++ b/skytap/resource_skytap_vm_test.go
@@ -457,15 +457,14 @@ func TestAccExternalPorts(t *testing.T) {
 }
 func testAccCheckSkytapExternalPorts(t *testing.T, vmName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		rsVM, err := getResource(s, vmName)
-		if err != nil {
-			return err
-		}
-		// TODO
-		//portMap, ok := rsVM.Primary.Meta["external_ports"].(map[string]interface{})
+		//rsVM, err := getResource(s, vmName)
+		//if err != nil {
+		//	return err
+		//}
+		//portMap, ok := rsVM.Primary.Attributes["external_ports"].(map[string]interface{})
 		//assert.True(t, ok)
-		//assert.NotEmpty(t, portMap["10_0_3_2:22"], "empty map entry")
-		//assert.NotEmpty(t, portMap["10_0_3_2:80"], "empty map entry")
+		//assert.NotEmpty(t, portMap["10-0-3-2_22"], "empty map entry")
+		//assert.NotEmpty(t, portMap["10-0-3-2_80"], "empty map entry")
 		return nil
 	}
 }

--- a/skytap/resource_skytap_vm_test.go
+++ b/skytap/resource_skytap_vm_test.go
@@ -414,6 +414,62 @@ func TestAccCasandra(t *testing.T) {
 	})
 }
 
+func TestAccExternalPorts(t *testing.T) {
+
+	if os.Getenv("SKYTAP_TEMPLATE_ID") == "" {
+		log.Printf("[WARN] SKYTAP_TEMPLATE_ID required to run skytap_vm_resource acceptance tests. Setting: SKYTAP_TEMPLATE_ID=1473407")
+		os.Setenv("SKYTAP_TEMPLATE_ID", "1473407")
+	}
+	if os.Getenv("SKYTAP_VM_ID") == "" {
+		log.Printf("[WARN] SKYTAP_VM_ID required to run skytap_vm_resource acceptance tests. Setting: SKYTAP_VM_ID=37865463")
+		os.Setenv("SKYTAP_VM_ID", "37865463")
+	}
+
+	uniqueSuffixEnv := acctest.RandInt()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckSkytapEnvironmentDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSkytapVMConfig_cassandra(os.Getenv("SKYTAP_TEMPLATE_ID"), os.Getenv("SKYTAP_VM_ID"), uniqueSuffixEnv, 23,
+					`"published_service" = {"internal_port" = 8080}`,
+					`"network_interface" = {
+    	              "interface_type" = "vmxnet3"
+        	          "network_id"     = "${skytap_network.dev_network.id}"
+        	          "ip"         = "10.0.3.2"
+                      "hostname" = "myhost2"
+
+        	          "published_service" = {
+          	            "internal_port" = 22
+        	          }
+        	          "published_service" = {
+          	            "internal_port" = 80
+        	          }
+      	            }`),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSkytapExternalPorts(t, "skytap_vm.cassandra1"),
+				),
+			},
+		},
+	})
+}
+func testAccCheckSkytapExternalPorts(t *testing.T, vmName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rsVM, err := getResource(s, vmName)
+		if err != nil {
+			return err
+		}
+		// TODO
+		//portMap, ok := rsVM.Primary.Meta["external_ports"].(map[string]interface{})
+		//assert.True(t, ok)
+		//assert.NotEmpty(t, portMap["10_0_3_2:22"], "empty map entry")
+		//assert.NotEmpty(t, portMap["10_0_3_2:80"], "empty map entry")
+		return nil
+	}
+}
+
 func testAccSkytapVMConfig_cassandra(templateID string, vmID string, uniqueSuffixEnv int, existingPort int, extraPublishedService string, extraNIC string) string {
 	config := fmt.Sprintf(`
 

--- a/skytap/structures.go
+++ b/skytap/structures.go
@@ -51,6 +51,6 @@ func flattenPublishedService(v skytap.PublishedService, ip string, externalIPMap
 	result["external_port"] = *v.ExternalPort
 	key := strings.Replace(ip, ".", "-", -1) + "_" + strconv.Itoa(*v.InternalPort)
 	externalIPMaps[0][key] = *v.ExternalIP
-	externalIPMaps[1][key] = strconv.Itoa(*v.ExternalPort)
+	externalIPMaps[1][key] = *v.ExternalPort
 	return result
 }

--- a/skytap/structures.go
+++ b/skytap/structures.go
@@ -8,44 +8,49 @@ import (
 	"github.com/skytap/skytap-sdk-go/skytap"
 )
 
-func flattenNetworkInterfaces(interfaces []skytap.Interface, externalPortMap map[string]interface{}) *schema.Set {
+func flattenNetworkInterfaces(interfaces []skytap.Interface, externalIPMaps []map[string]interface{}) *schema.Set {
 	results := make([]interface{}, 0)
 
 	for _, v := range interfaces {
-		results = append(results, flattenNetworkInterface(v, externalPortMap))
+		results = append(results, flattenNetworkInterface(v, externalIPMaps))
 	}
 
 	return schema.NewSet(networkInterfaceHash, results)
 }
 
-func flattenNetworkInterface(v skytap.Interface, externalPortMap map[string]interface{}) map[string]interface{} {
+func flattenNetworkInterface(v skytap.Interface,
+	externalIPMaps []map[string]interface{}) map[string]interface{} {
 	result := make(map[string]interface{})
 	result["interface_type"] = string(*v.NICType)
 	result["network_id"] = *v.NetworkID
 	result["ip"] = *v.IP
 	result["hostname"] = *v.Hostname
 	if len(v.Services) > 0 {
-		result["published_service"] = flattenPublishedServices(v.Services, *v.IP, externalPortMap)
+		result["published_service"] = flattenPublishedServices(v.Services, *v.IP,
+			externalIPMaps)
 	}
 	return result
 }
 
-func flattenPublishedServices(publishedServices []skytap.PublishedService, ip string, externalPortMap map[string]interface{}) *schema.Set {
+func flattenPublishedServices(publishedServices []skytap.PublishedService, ip string,
+	externalIPMaps []map[string]interface{}) *schema.Set {
 	results := make([]interface{}, 0)
 
 	for _, v := range publishedServices {
-		results = append(results, flattenPublishedService(v, ip, externalPortMap))
+		results = append(results, flattenPublishedService(v, ip, externalIPMaps))
 	}
 
 	return schema.NewSet(publishedServiceHash, results)
 }
 
-func flattenPublishedService(v skytap.PublishedService, ip string, externalPortMap map[string]interface{}) map[string]interface{} {
+func flattenPublishedService(v skytap.PublishedService, ip string, externalIPMaps []map[string]interface{}) map[string]interface{} {
 	result := make(map[string]interface{})
 	result["id"] = *v.ID
 	result["internal_port"] = *v.InternalPort
 	result["external_ip"] = *v.ExternalIP
 	result["external_port"] = *v.ExternalPort
-	externalPortMap[strings.Replace(ip, ".", "-", -1)+"_"+strconv.Itoa(*v.InternalPort)] = *v.ExternalPort
+	key := strings.Replace(ip, ".", "-", -1) + "_" + strconv.Itoa(*v.InternalPort)
+	externalIPMaps[0][key] = *v.ExternalIP
+	externalIPMaps[1][key] = *v.ExternalPort
 	return result
 }

--- a/skytap/structures.go
+++ b/skytap/structures.go
@@ -1,47 +1,51 @@
 package skytap
 
 import (
+	"strconv"
+	"strings"
+
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/skytap/skytap-sdk-go/skytap"
 )
 
-func flattenNetworkInterfaces(interfaces []skytap.Interface) *schema.Set {
+func flattenNetworkInterfaces(interfaces []skytap.Interface, externalPortMap map[string]interface{}) *schema.Set {
 	results := make([]interface{}, 0)
 
 	for _, v := range interfaces {
-		results = append(results, flattenNetworkInterface(v))
+		results = append(results, flattenNetworkInterface(v, externalPortMap))
 	}
 
 	return schema.NewSet(networkInterfaceHash, results)
 }
 
-func flattenNetworkInterface(v skytap.Interface) map[string]interface{} {
+func flattenNetworkInterface(v skytap.Interface, externalPortMap map[string]interface{}) map[string]interface{} {
 	result := make(map[string]interface{})
 	result["interface_type"] = string(*v.NICType)
 	result["network_id"] = *v.NetworkID
 	result["ip"] = *v.IP
 	result["hostname"] = *v.Hostname
 	if len(v.Services) > 0 {
-		result["published_service"] = flattenPublishedServices(v.Services)
+		result["published_service"] = flattenPublishedServices(v.Services, *v.IP, externalPortMap)
 	}
 	return result
 }
 
-func flattenPublishedServices(publishedServices []skytap.PublishedService) *schema.Set {
+func flattenPublishedServices(publishedServices []skytap.PublishedService, ip string, externalPortMap map[string]interface{}) *schema.Set {
 	results := make([]interface{}, 0)
 
 	for _, v := range publishedServices {
-		results = append(results, flattenPublishedService(v))
+		results = append(results, flattenPublishedService(v, ip, externalPortMap))
 	}
 
 	return schema.NewSet(publishedServiceHash, results)
 }
 
-func flattenPublishedService(v skytap.PublishedService) map[string]interface{} {
+func flattenPublishedService(v skytap.PublishedService, ip string, externalPortMap map[string]interface{}) map[string]interface{} {
 	result := make(map[string]interface{})
 	result["id"] = *v.ID
 	result["internal_port"] = *v.InternalPort
 	result["external_ip"] = *v.ExternalIP
 	result["external_port"] = *v.ExternalPort
+	externalPortMap[strings.Replace(ip, ".", "_", -1)+":"+strconv.Itoa(*v.InternalPort)] = *v.ExternalPort
 	return result
 }

--- a/skytap/structures.go
+++ b/skytap/structures.go
@@ -46,6 +46,6 @@ func flattenPublishedService(v skytap.PublishedService, ip string, externalPortM
 	result["internal_port"] = *v.InternalPort
 	result["external_ip"] = *v.ExternalIP
 	result["external_port"] = *v.ExternalPort
-	externalPortMap[strings.Replace(ip, ".", "_", -1)+":"+strconv.Itoa(*v.InternalPort)] = *v.ExternalPort
+	externalPortMap[strings.Replace(ip, ".", "-", -1)+"_"+strconv.Itoa(*v.InternalPort)] = *v.ExternalPort
 	return result
 }

--- a/skytap/structures.go
+++ b/skytap/structures.go
@@ -51,6 +51,6 @@ func flattenPublishedService(v skytap.PublishedService, ip string, externalIPMap
 	result["external_port"] = *v.ExternalPort
 	key := strings.Replace(ip, ".", "-", -1) + "_" + strconv.Itoa(*v.InternalPort)
 	externalIPMaps[0][key] = *v.ExternalIP
-	externalIPMaps[1][key] = *v.ExternalPort
+	externalIPMaps[1][key] = strconv.Itoa(*v.ExternalPort)
 	return result
 }

--- a/skytap/structures_test.go
+++ b/skytap/structures_test.go
@@ -190,7 +190,7 @@ func TestFlattenPublishedServices(t *testing.T) {
 }
 
 func TestFlattenInterfacesPortMap(t *testing.T) {
-	expectedKeys := []string{"192_168_0_1:8080", "192_168_0_1:8081", "192_168_0_2:8080", "192_168_0_2:8081"}
+	expectedKeys := []string{"192-168-0-1_8080", "192-168-0-1_8081", "192-168-0-2_8080", "192-168-0-2_8081"}
 	expectedValues := []int{26160, 17785, 26160, 17785}
 
 	var portMap = make(map[string]interface{})

--- a/skytap/structures_test.go
+++ b/skytap/structures_test.go
@@ -66,17 +66,86 @@ const examplePublishedServiceListResponse = `[
     }
 ]`
 
+const exampleInterfaceAndPortsListResponse = `[
+    {
+        "id": "nic-20246343-38367563-0",
+        "ip": "192.168.0.1",
+        "hostname": "wins2016s",
+        "mac": "00:50:56:11:7D:D9",
+        "services_count": 0,
+        "services": [
+	    {
+            "id": "8080",
+            "internal_port": 8080,
+            "external_ip": "services-uswest.skytap.com",
+            "external_port": 26160
+        },
+        {
+            "id": "8081",
+            "internal_port": 8081,
+            "external_ip": "services-useast.skytap.com",
+            "external_port": 17785
+    	}
+        ],
+        "public_ips_count": 0,
+        "public_ips": [],
+        "vm_id": "37527239",
+        "vm_name": "Windows Server 2016 Standard",
+        "status": "Running",
+        "network_id": "23917287",
+        "network_name": "tftest-network-1",
+        "network_url": "https://cloud.skytap.com/v2/configurations/40064014/networks/23917287",
+        "network_type": "automatic",
+        "network_subnet": "192.168.0.0/16",
+        "nic_type": "vmxnet3",
+        "secondary_ips": [],
+        "public_ip_attachments": []
+    },
+    {
+        "id": "nic-20246343-38367563-5",
+        "ip": "192.168.0.2",
+        "hostname": "wins2016s2",
+        "mac": "00:50:56:07:40:3F",
+        "services_count": 0,
+        "services": [
+	    {
+            "id": "8080",
+            "internal_port": 8080,
+            "external_ip": "services-uswest.skytap.com",
+            "external_port": 26160
+        },
+        {
+            "id": "8081",
+            "internal_port": 8081,
+            "external_ip": "services-useast.skytap.com",
+            "external_port": 17785
+    	}
+        ],
+        "public_ips_count": 0,
+        "public_ips": [],
+        "vm_id": "37527239",
+        "vm_name": "Windows Server 2016 Standard",
+        "status": "Running",
+        "network_id": "23917287",
+        "nic_type": "e1000",
+        "secondary_ips": [],
+        "public_ip_attachments": []
+    }
+]`
+
 func TestFlattenInterfaces(t *testing.T) {
 
 	expected := make(map[string][]string)
 	expected["ip"] = []string{"192.168.0.1", "192.168.0.2"}
 	expected["hostname"] = []string{"wins2016s", "wins2016s2"}
 
+	var portMap = make(map[string]interface{})
+
 	var interfaces []skytap.Interface
 	json.Unmarshal([]byte(exampleInterfaceListResponse), &interfaces)
 	var networkInterfaces = make([]map[string]interface{}, 0)
 	for _, v := range interfaces {
-		networkInterfaces = append(networkInterfaces, flattenNetworkInterface(v))
+		networkInterfaces = append(networkInterfaces, flattenNetworkInterface(v, portMap))
 	}
 	assert.True(t, len(networkInterfaces) == 2, fmt.Sprintf("expecting: %d but received: %d", 2, len(networkInterfaces)))
 	for i := 0; i < len(networkInterfaces); i++ {
@@ -96,11 +165,13 @@ func TestFlattenPublishedServices(t *testing.T) {
 	expected["external_ip"] = []string{"services-uswest.skytap.com", "services-useast.skytap.com"}
 	expected["external_port"] = []string{"26160", "17785"}
 
+	var portMap = make(map[string]interface{})
+
 	var services []skytap.PublishedService
 	json.Unmarshal([]byte(examplePublishedServiceListResponse), &services)
 	var publishedServices = make([]map[string]interface{}, 0)
 	for _, v := range services {
-		publishedServices = append(publishedServices, flattenPublishedService(v))
+		publishedServices = append(publishedServices, flattenPublishedService(v, "", portMap))
 	}
 	assert.True(t, len(publishedServices) == 2, fmt.Sprintf("expecting: %d but received: %d", 2, len(publishedServices)))
 	for i := 0; i < len(publishedServices); i++ {
@@ -115,5 +186,26 @@ func TestFlattenPublishedServices(t *testing.T) {
 					fmt.Sprintf("expecting: %s but received: %s", value[i], valueAsString))
 			}
 		}
+	}
+}
+
+func TestFlattenInterfacesPortMap(t *testing.T) {
+	expectedKeys := []string{"192_168_0_1:8080", "192_168_0_1:8081", "192_168_0_2:8080", "192_168_0_2:8081"}
+	expectedValues := []int{26160, 17785, 26160, 17785}
+
+	var portMap = make(map[string]interface{})
+
+	var interfaces []skytap.Interface
+	json.Unmarshal([]byte(exampleInterfaceAndPortsListResponse), &interfaces)
+	var networkInterfaces = make([]map[string]interface{}, 0)
+	for _, v := range interfaces {
+		networkInterfaces = append(networkInterfaces, flattenNetworkInterface(v, portMap))
+	}
+
+	count := 0
+	for key, value := range portMap {
+		assert.Equal(t, expectedKeys[count], key, "key")
+		assert.Equal(t, expectedValues[count], value, "value")
+		count++
 	}
 }

--- a/skytap/structures_test.go
+++ b/skytap/structures_test.go
@@ -193,7 +193,7 @@ func TestFlattenInterfacesIPMap(t *testing.T) {
 	expectedKeys1 := []string{"192-168-0-1_8080", "192-168-0-1_8081", "192-168-0-2_8080", "192-168-0-2_8081"}
 	expectedValues1 := []string{"services-uswest.skytap.com", "services-useast.skytap.com", "services-uswest.skytap.com", "services-useast.skytap.com"}
 	expectedKeys2 := []string{"192-168-0-1_8080", "192-168-0-1_8081", "192-168-0-2_8080", "192-168-0-2_8081"}
-	expectedValues2 := []int{26160, 17785, 26160, 17785}
+	expectedValues2 := []string{"26160", "17785", "26160", "17785"}
 
 	var ipMaps = []map[string]interface{}{make(map[string]interface{}), make(map[string]interface{})}
 
@@ -205,15 +205,13 @@ func TestFlattenInterfacesIPMap(t *testing.T) {
 	}
 
 	count := 0
-	for key, value := range ipMaps[0] {
-		assert.Equal(t, expectedKeys1[count], key, "key")
-		assert.Equal(t, expectedValues1[count], value, "value")
+	for _, key := range expectedKeys1 {
+		assert.Equal(t, expectedValues1[count], ipMaps[0][key], "value")
 		count++
 	}
 	count = 0
-	for key, value := range ipMaps[1] {
-		assert.Equal(t, expectedKeys2[count], key, "key")
-		assert.Equal(t, expectedValues2[count], value, "value")
+	for _, key := range expectedKeys2 {
+		assert.Equal(t, expectedValues2[count], ipMaps[1][key], "value")
 		count++
 	}
 }

--- a/skytap/structures_test.go
+++ b/skytap/structures_test.go
@@ -139,13 +139,13 @@ func TestFlattenInterfaces(t *testing.T) {
 	expected["ip"] = []string{"192.168.0.1", "192.168.0.2"}
 	expected["hostname"] = []string{"wins2016s", "wins2016s2"}
 
-	var portMap = make(map[string]interface{})
+	var ipMaps = []map[string]interface{}{make(map[string]interface{}), make(map[string]interface{})}
 
 	var interfaces []skytap.Interface
 	json.Unmarshal([]byte(exampleInterfaceListResponse), &interfaces)
 	var networkInterfaces = make([]map[string]interface{}, 0)
 	for _, v := range interfaces {
-		networkInterfaces = append(networkInterfaces, flattenNetworkInterface(v, portMap))
+		networkInterfaces = append(networkInterfaces, flattenNetworkInterface(v, ipMaps))
 	}
 	assert.True(t, len(networkInterfaces) == 2, fmt.Sprintf("expecting: %d but received: %d", 2, len(networkInterfaces)))
 	for i := 0; i < len(networkInterfaces); i++ {
@@ -165,13 +165,13 @@ func TestFlattenPublishedServices(t *testing.T) {
 	expected["external_ip"] = []string{"services-uswest.skytap.com", "services-useast.skytap.com"}
 	expected["external_port"] = []string{"26160", "17785"}
 
-	var portMap = make(map[string]interface{})
+	var ipMaps = []map[string]interface{}{make(map[string]interface{}), make(map[string]interface{})}
 
 	var services []skytap.PublishedService
 	json.Unmarshal([]byte(examplePublishedServiceListResponse), &services)
 	var publishedServices = make([]map[string]interface{}, 0)
 	for _, v := range services {
-		publishedServices = append(publishedServices, flattenPublishedService(v, "", portMap))
+		publishedServices = append(publishedServices, flattenPublishedService(v, "", ipMaps))
 	}
 	assert.True(t, len(publishedServices) == 2, fmt.Sprintf("expecting: %d but received: %d", 2, len(publishedServices)))
 	for i := 0; i < len(publishedServices); i++ {
@@ -189,23 +189,31 @@ func TestFlattenPublishedServices(t *testing.T) {
 	}
 }
 
-func TestFlattenInterfacesPortMap(t *testing.T) {
-	expectedKeys := []string{"192-168-0-1_8080", "192-168-0-1_8081", "192-168-0-2_8080", "192-168-0-2_8081"}
-	expectedValues := []int{26160, 17785, 26160, 17785}
+func TestFlattenInterfacesIPMap(t *testing.T) {
+	expectedKeys1 := []string{"192-168-0-1_8080", "192-168-0-1_8081", "192-168-0-2_8080", "192-168-0-2_8081"}
+	expectedValues1 := []string{"services-uswest.skytap.com", "services-useast.skytap.com", "services-uswest.skytap.com", "services-useast.skytap.com"}
+	expectedKeys2 := []string{"192-168-0-1_8080", "192-168-0-1_8081", "192-168-0-2_8080", "192-168-0-2_8081"}
+	expectedValues2 := []int{26160, 17785, 26160, 17785}
 
-	var portMap = make(map[string]interface{})
+	var ipMaps = []map[string]interface{}{make(map[string]interface{}), make(map[string]interface{})}
 
 	var interfaces []skytap.Interface
 	json.Unmarshal([]byte(exampleInterfaceAndPortsListResponse), &interfaces)
 	var networkInterfaces = make([]map[string]interface{}, 0)
 	for _, v := range interfaces {
-		networkInterfaces = append(networkInterfaces, flattenNetworkInterface(v, portMap))
+		networkInterfaces = append(networkInterfaces, flattenNetworkInterface(v, ipMaps))
 	}
 
 	count := 0
-	for key, value := range portMap {
-		assert.Equal(t, expectedKeys[count], key, "key")
-		assert.Equal(t, expectedValues[count], value, "value")
+	for key, value := range ipMaps[0] {
+		assert.Equal(t, expectedKeys1[count], key, "key")
+		assert.Equal(t, expectedValues1[count], value, "value")
+		count++
+	}
+	count = 0
+	for key, value := range ipMaps[1] {
+		assert.Equal(t, expectedKeys2[count], key, "key")
+		assert.Equal(t, expectedValues2[count], value, "value")
 		count++
 	}
 }

--- a/skytap/structures_test.go
+++ b/skytap/structures_test.go
@@ -3,6 +3,8 @@ package skytap
 import (
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
+	"path/filepath"
 	"strconv"
 	"testing"
 
@@ -10,130 +12,9 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-const exampleInterfaceListResponse = `[
-    {
-        "id": "nic-20246343-38367563-0",
-        "ip": "192.168.0.1",
-        "hostname": "wins2016s",
-        "mac": "00:50:56:11:7D:D9",
-        "services_count": 0,
-        "services": [],
-        "public_ips_count": 0,
-        "public_ips": [],
-        "vm_id": "37527239",
-        "vm_name": "Windows Server 2016 Standard",
-        "status": "Running",
-        "network_id": "23917287",
-        "network_name": "tftest-network-1",
-        "network_url": "https://cloud.skytap.com/v2/configurations/40064014/networks/23917287",
-        "network_type": "automatic",
-        "network_subnet": "192.168.0.0/16",
-        "nic_type": "vmxnet3",
-        "secondary_ips": [],
-        "public_ip_attachments": []
-    },
-    {
-        "id": "nic-20246343-38367563-5",
-        "ip": "192.168.0.2",
-        "hostname": "wins2016s2",
-        "mac": "00:50:56:07:40:3F",
-        "services_count": 0,
-        "services": [],
-        "public_ips_count": 0,
-        "public_ips": [],
-        "vm_id": "37527239",
-        "vm_name": "Windows Server 2016 Standard",
-        "status": "Running",
-        "network_id": "23917287",
-        "nic_type": "e1000",
-        "secondary_ips": [],
-        "public_ip_attachments": []
-    }
-]`
-
-const examplePublishedServiceListResponse = `[
-    {
-        "id": "8080",
-        "internal_port": 8080,
-        "external_ip": "services-uswest.skytap.com",
-        "external_port": 26160
-    },
-    {
-        "id": "8081",
-        "internal_port": 8081,
-        "external_ip": "services-useast.skytap.com",
-        "external_port": 17785
-    }
-]`
-
-const exampleInterfaceAndPortsListResponse = `[
-    {
-        "id": "nic-20246343-38367563-0",
-        "ip": "192.168.0.1",
-        "hostname": "wins2016s",
-        "mac": "00:50:56:11:7D:D9",
-        "services_count": 0,
-        "services": [
-	    {
-            "id": "8080",
-            "internal_port": 8080,
-            "external_ip": "services-uswest.skytap.com",
-            "external_port": 26160
-        },
-        {
-            "id": "8081",
-            "internal_port": 8081,
-            "external_ip": "services-useast.skytap.com",
-            "external_port": 17785
-    	}
-        ],
-        "public_ips_count": 0,
-        "public_ips": [],
-        "vm_id": "37527239",
-        "vm_name": "Windows Server 2016 Standard",
-        "status": "Running",
-        "network_id": "23917287",
-        "network_name": "tftest-network-1",
-        "network_url": "https://cloud.skytap.com/v2/configurations/40064014/networks/23917287",
-        "network_type": "automatic",
-        "network_subnet": "192.168.0.0/16",
-        "nic_type": "vmxnet3",
-        "secondary_ips": [],
-        "public_ip_attachments": []
-    },
-    {
-        "id": "nic-20246343-38367563-5",
-        "ip": "192.168.0.2",
-        "hostname": "wins2016s2",
-        "mac": "00:50:56:07:40:3F",
-        "services_count": 0,
-        "services": [
-	    {
-            "id": "8080",
-            "internal_port": 8080,
-            "external_ip": "services-uswest.skytap.com",
-            "external_port": 26160
-        },
-        {
-            "id": "8081",
-            "internal_port": 8081,
-            "external_ip": "services-useast.skytap.com",
-            "external_port": 17785
-    	}
-        ],
-        "public_ips_count": 0,
-        "public_ips": [],
-        "vm_id": "37527239",
-        "vm_name": "Windows Server 2016 Standard",
-        "status": "Running",
-        "network_id": "23917287",
-        "nic_type": "e1000",
-        "secondary_ips": [],
-        "public_ip_attachments": []
-    }
-]`
-
 func TestFlattenInterfaces(t *testing.T) {
+
+	response := string(readTestFile(t, "vm_interface_response.json"))
 
 	expected := make(map[string][]string)
 	expected["ip"] = []string{"192.168.0.1", "192.168.0.2"}
@@ -142,7 +23,10 @@ func TestFlattenInterfaces(t *testing.T) {
 	var ipMaps = []map[string]interface{}{make(map[string]interface{}), make(map[string]interface{})}
 
 	var interfaces []skytap.Interface
-	json.Unmarshal([]byte(exampleInterfaceListResponse), &interfaces)
+	err := json.Unmarshal([]byte(response), &interfaces)
+	if err != nil {
+		t.Fatal(err)
+	}
 	var networkInterfaces = make([]map[string]interface{}, 0)
 	for _, v := range interfaces {
 		networkInterfaces = append(networkInterfaces, flattenNetworkInterface(v, ipMaps))
@@ -159,6 +43,8 @@ func TestFlattenInterfaces(t *testing.T) {
 
 func TestFlattenPublishedServices(t *testing.T) {
 
+	response := string(readTestFile(t, "vm_interface_services_response.json"))
+
 	expected := make(map[string][]string)
 	expected["id"] = []string{"8080", "8081"}
 	expected["internal_port"] = []string{"8080", "8081"}
@@ -168,7 +54,10 @@ func TestFlattenPublishedServices(t *testing.T) {
 	var ipMaps = []map[string]interface{}{make(map[string]interface{}), make(map[string]interface{})}
 
 	var services []skytap.PublishedService
-	json.Unmarshal([]byte(examplePublishedServiceListResponse), &services)
+	err := json.Unmarshal([]byte(response), &services)
+	if err != nil {
+		t.Fatal(err)
+	}
 	var publishedServices = make([]map[string]interface{}, 0)
 	for _, v := range services {
 		publishedServices = append(publishedServices, flattenPublishedService(v, "", ipMaps))
@@ -190,15 +79,21 @@ func TestFlattenPublishedServices(t *testing.T) {
 }
 
 func TestFlattenInterfacesIPMap(t *testing.T) {
+
+	response := string(readTestFile(t, "vm_interface_ports_response.json"))
+
 	expectedKeys1 := []string{"192-168-0-1_8080", "192-168-0-1_8081", "192-168-0-2_8080", "192-168-0-2_8081"}
 	expectedValues1 := []string{"services-uswest.skytap.com", "services-useast.skytap.com", "services-uswest.skytap.com", "services-useast.skytap.com"}
 	expectedKeys2 := []string{"192-168-0-1_8080", "192-168-0-1_8081", "192-168-0-2_8080", "192-168-0-2_8081"}
-	expectedValues2 := []string{"26160", "17785", "26160", "17785"}
+	expectedValues2 := []int{26160, 17785, 26160, 17785}
 
 	var ipMaps = []map[string]interface{}{make(map[string]interface{}), make(map[string]interface{})}
 
 	var interfaces []skytap.Interface
-	json.Unmarshal([]byte(exampleInterfaceAndPortsListResponse), &interfaces)
+	err := json.Unmarshal([]byte(response), &interfaces)
+	if err != nil {
+		t.Fatal(err)
+	}
 	var networkInterfaces = make([]map[string]interface{}, 0)
 	for _, v := range interfaces {
 		networkInterfaces = append(networkInterfaces, flattenNetworkInterface(v, ipMaps))
@@ -214,4 +109,13 @@ func TestFlattenInterfacesIPMap(t *testing.T) {
 		assert.Equal(t, expectedValues2[count], ipMaps[1][key], "value")
 		count++
 	}
+}
+
+func readTestFile(t *testing.T, name string) []byte {
+	path := filepath.Join("testdata", name) // relative path
+	bytes, err := ioutil.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return bytes
 }

--- a/skytap/testdata/vm_interface_ports_response.json
+++ b/skytap/testdata/vm_interface_ports_response.json
@@ -1,0 +1,66 @@
+[
+    {
+        "id": "nic-20246343-38367563-0",
+        "ip": "192.168.0.1",
+        "hostname": "wins2016s",
+        "mac": "00:50:56:11:7D:D9",
+        "services_count": 0,
+        "services": [
+	    {
+            "id": "8080",
+            "internal_port": 8080,
+            "external_ip": "services-uswest.skytap.com",
+            "external_port": 26160
+        },
+        {
+            "id": "8081",
+            "internal_port": 8081,
+            "external_ip": "services-useast.skytap.com",
+            "external_port": 17785
+    	}
+        ],
+        "public_ips_count": 0,
+        "public_ips": [],
+        "vm_id": "37527239",
+        "vm_name": "Windows Server 2016 Standard",
+        "status": "Running",
+        "network_id": "23917287",
+        "network_name": "tftest-network-1",
+        "network_url": "https://cloud.skytap.com/v2/configurations/40064014/networks/23917287",
+        "network_type": "automatic",
+        "network_subnet": "192.168.0.0/16",
+        "nic_type": "vmxnet3",
+        "secondary_ips": [],
+        "public_ip_attachments": []
+    },
+    {
+        "id": "nic-20246343-38367563-5",
+        "ip": "192.168.0.2",
+        "hostname": "wins2016s2",
+        "mac": "00:50:56:07:40:3F",
+        "services_count": 0,
+        "services": [
+	    {
+            "id": "8080",
+            "internal_port": 8080,
+            "external_ip": "services-uswest.skytap.com",
+            "external_port": 26160
+        },
+        {
+            "id": "8081",
+            "internal_port": 8081,
+            "external_ip": "services-useast.skytap.com",
+            "external_port": 17785
+    	}
+        ],
+        "public_ips_count": 0,
+        "public_ips": [],
+        "vm_id": "37527239",
+        "vm_name": "Windows Server 2016 Standard",
+        "status": "Running",
+        "network_id": "23917287",
+        "nic_type": "e1000",
+        "secondary_ips": [],
+        "public_ip_attachments": []
+    }
+]

--- a/skytap/testdata/vm_interface_response.json
+++ b/skytap/testdata/vm_interface_response.json
@@ -1,0 +1,40 @@
+[
+{
+"id": "nic-20246343-38367563-0",
+"ip": "192.168.0.1",
+"hostname": "wins2016s",
+"mac": "00:50:56:11:7D:D9",
+"services_count": 0,
+"services": [],
+"public_ips_count": 0,
+"public_ips": [],
+"vm_id": "37527239",
+"vm_name": "Windows Server 2016 Standard",
+"status": "Running",
+"network_id": "23917287",
+"network_name": "tftest-network-1",
+"network_url": "https://cloud.skytap.com/v2/configurations/40064014/networks/23917287",
+"network_type": "automatic",
+"network_subnet": "192.168.0.0/16",
+"nic_type": "vmxnet3",
+"secondary_ips": [],
+"public_ip_attachments": []
+},
+{
+"id": "nic-20246343-38367563-5",
+"ip": "192.168.0.2",
+"hostname": "wins2016s2",
+"mac": "00:50:56:07:40:3F",
+"services_count": 0,
+"services": [],
+"public_ips_count": 0,
+"public_ips": [],
+"vm_id": "37527239",
+"vm_name": "Windows Server 2016 Standard",
+"status": "Running",
+"network_id": "23917287",
+"nic_type": "e1000",
+"secondary_ips": [],
+"public_ip_attachments": []
+}
+]

--- a/skytap/testdata/vm_interface_services_response.json
+++ b/skytap/testdata/vm_interface_services_response.json
@@ -1,0 +1,14 @@
+[
+  {
+    "id": "8080",
+    "internal_port": 8080,
+    "external_ip": "services-uswest.skytap.com",
+    "external_port": 26160
+  },
+  {
+    "id": "8081",
+    "internal_port": 8081,
+    "external_ip": "services-useast.skytap.com",
+    "external_port": 17785
+  }
+]

--- a/skytap/utils/utils.go
+++ b/skytap/utils/utils.go
@@ -1,6 +1,8 @@
 package utils
 
-import "github.com/skytap/skytap-sdk-go/skytap"
+import (
+	"github.com/skytap/skytap-sdk-go/skytap"
+)
 
 // String returns a pointer to a string literal
 func String(s string) *string {

--- a/website/docs/r/vm.html.md
+++ b/website/docs/r/vm.html.md
@@ -21,12 +21,30 @@ Provides a Skytap Virtual Machine (VM) resource. The environment VM resource rep
 
 ```hcl
 # Create a new vm
-resource "skytap_vm" "vm" {
+resource "skytap_vm" "my_vm" {
   template_id = 123
   vm_id = 456
   environment_id = 789
   name = "my vm"
+  
+  network_interface = {
+       interface_type = "vmxnet3"
+       network_id = "${skytap_network.my_network.id}"
+       ip = "10.0.0.1"
+       hostname = "myhost"
+    
+       published_service = {
+          internal_port = 80
+       }
+   }
 }
+output "external_svc_ip" {
+    value = "${skytap_vm.my_vm.external_ips.10-0-0-1_80}"
+}
+output "external_svc_port" {
+    value = "${skytap_vm.my_vm.external_ports.10-0-0-1_80}"
+}
+
 ```
 
 ## Argument Reference
@@ -45,10 +63,11 @@ The following arguments are supported:
   * `network_id` - (Required, Force New) ID of the network that this network adapter is attached to.
   *	`ip` - (Required, Force New) The IP address (for example, 10.1.0.37). Skytap will not assign the same IP address to multiple interfaces on the same network.
   * `hostname` - (Required, Force New) Limited to 32 characters. Valid characters are lowercase letters, numbers, and hyphens. Cannot begin or end with hyphens. Cannot be `gw`.
-* `published_service` - (Optional, Force New) Generally, a published service represents a binding of a port on a network interface to an IP and port that is routable and accessible from the public Internet. This mechanism is used to selectively expose ports on the guest to the public Internet.
 
-  ~> **NOTE:** Published services exist and are managed as aspects of network interfaces—that is, as part of the overall environment element.
-  * `internal_port` - (Required, Force New) The port that is exposed on the interface. Typically this will be dictated by standard usage (e.g., port 80 for http traffic, port 22 for SSH).
+  * `published_service` - (Optional, Force New) Generally, a published service represents a binding of a port on a network interface to an IP and port that is routable and accessible from the public Internet. This mechanism is used to selectively expose ports on the guest to the public Internet.
+
+    ~> **NOTE:** Published services exist and are managed as aspects of network interfaces—that is, as part of the overall environment element.
+    * `internal_port` - (Required, Force New) The port that is exposed on the interface. Typically this will be dictated by standard usage (e.g., port 80 for http traffic, port 22 for SSH).
 
 ## Attributes Reference
 
@@ -59,3 +78,5 @@ The following attributes are exported:
   * `id`: The published service's ID.
   * `external_id`: The published service's external ID.
   * `external_port`: Each published service's external port.
+* `external_ips`: A map of external IP addresses. The key is the internal IP address together with the internal port number - as defined in the `network_interface` block.
+* `external_ports`: A map of external ports. The key is the internal IP address together with the internal port number - as defined in the `network_interface` block.


### PR DESCRIPTION
Each network interface is contained within a set. Within each set is a set of published services. Both sets will contain computed values. Access to these values is required within the terraform state files.
The values are:
External IP address
External port for the published services.

The documentation contains instructions on how to use the new attributes.