### PR TITLE
#2 Add disk create to VM resource

### DIFF
--- a/skytap/resource_skytap_vm_test.go
+++ b/skytap/resource_skytap_vm_test.go
@@ -60,13 +60,19 @@ func TestAccSkytapVM_Basic(t *testing.T) {
 
 	if os.Getenv("SKYTAP_TEMPLATE_ID") == "" {
 		log.Printf("[WARN] SKYTAP_TEMPLATE_ID required to run skytap_vm_resource acceptance tests. Setting: SKYTAP_TEMPLATE_ID=1473407")
-		os.Setenv("SKYTAP_TEMPLATE_ID", "1473407")
+		err := os.Setenv("SKYTAP_TEMPLATE_ID", "1473407")
+		assert.NoError(t, err)
 	}
 	if os.Getenv("SKYTAP_VM_ID") == "" {
 		log.Printf("[WARN] SKYTAP_VM_ID required to run skytap_vm_resource acceptance tests. Setting: SKYTAP_VM_ID=37865463")
-		os.Setenv("SKYTAP_VM_ID", "37865463")
+		err := os.Setenv("SKYTAP_VM_ID", "37865463")
+		assert.NoError(t, err)
 	}
-
+	newEnvTemplateID := os.Getenv("SKYTAP_TEMPLATE_ID")
+	if os.Getenv("SKYTAP_TEMPLATE_NEW_ENV_ID") != "" {
+		newEnvTemplateID = os.Getenv("SKYTAP_TEMPLATE_NEW_ENV_ID")
+		log.Printf("[DEBUG] SKYTAP_TEMPLATE_NEW_ENV_ID=%s", newEnvTemplateID)
+	}
 	uniqueSuffixEnv := acctest.RandInt()
 	var vm skytap.VM
 
@@ -76,7 +82,7 @@ func TestAccSkytapVM_Basic(t *testing.T) {
 		CheckDestroy: testAccCheckSkytapEnvironmentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSkytapVMConfig_basic(os.Getenv("SKYTAP_TEMPLATE_ID"), uniqueSuffixEnv, "", os.Getenv("SKYTAP_TEMPLATE_ID"), os.Getenv("SKYTAP_VM_ID"), "name = \"test\"", "", ``),
+				Config: testAccSkytapVMConfig_basic(newEnvTemplateID, uniqueSuffixEnv, "", os.Getenv("SKYTAP_TEMPLATE_ID"), os.Getenv("SKYTAP_VM_ID"), "name = \"test\"", "", ``),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSkytapVMExists("skytap_environment.foo", "skytap_vm.bar", &vm),
 					resource.TestCheckResourceAttr("skytap_vm.bar", "name", "test"),
@@ -92,13 +98,19 @@ func TestAccSkytapVM_Update(t *testing.T) {
 
 	if os.Getenv("SKYTAP_TEMPLATE_ID") == "" {
 		log.Printf("[WARN] SKYTAP_TEMPLATE_ID required to run skytap_vm_resource acceptance tests. Setting: SKYTAP_TEMPLATE_ID=1473407")
-		os.Setenv("SKYTAP_TEMPLATE_ID", "1473407")
+		err := os.Setenv("SKYTAP_TEMPLATE_ID", "1473407")
+		assert.NoError(t, err)
 	}
 	if os.Getenv("SKYTAP_VM_ID") == "" {
 		log.Printf("[WARN] SKYTAP_VM_ID required to run skytap_vm_resource acceptance tests. Setting: SKYTAP_VM_ID=37865463")
-		os.Setenv("SKYTAP_VM_ID", "37865463")
+		err := os.Setenv("SKYTAP_VM_ID", "37865463")
+		assert.NoError(t, err)
 	}
-
+	newEnvTemplateID := os.Getenv("SKYTAP_TEMPLATE_ID")
+	if os.Getenv("SKYTAP_TEMPLATE_NEW_ENV_ID") != "" {
+		newEnvTemplateID = os.Getenv("SKYTAP_TEMPLATE_NEW_ENV_ID")
+		log.Printf("[DEBUG] SKYTAP_TEMPLATE_NEW_ENV_ID=%s", newEnvTemplateID)
+	}
 	uniqueSuffixEnv := acctest.RandInt()
 	uniqueSuffixVM := acctest.RandInt()
 	var vm skytap.VM
@@ -109,7 +121,7 @@ func TestAccSkytapVM_Update(t *testing.T) {
 		CheckDestroy: testAccCheckSkytapEnvironmentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSkytapVMConfig_basic(os.Getenv("SKYTAP_TEMPLATE_ID"), uniqueSuffixEnv, "", os.Getenv("SKYTAP_TEMPLATE_ID"), os.Getenv("SKYTAP_VM_ID"), "", "", ``),
+				Config: testAccSkytapVMConfig_basic(newEnvTemplateID, uniqueSuffixEnv, "", os.Getenv("SKYTAP_TEMPLATE_ID"), os.Getenv("SKYTAP_VM_ID"), "", "", ``),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSkytapVMExists("skytap_environment.foo", "skytap_vm.bar", &vm),
 					resource.TestCheckResourceAttrSet("skytap_vm.bar", "name"),
@@ -117,7 +129,7 @@ func TestAccSkytapVM_Update(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccSkytapVMConfig_basic(os.Getenv("SKYTAP_TEMPLATE_ID"), uniqueSuffixEnv, "", os.Getenv("SKYTAP_TEMPLATE_ID"), os.Getenv("SKYTAP_VM_ID"),
+				Config: testAccSkytapVMConfig_basic(newEnvTemplateID, uniqueSuffixEnv, "", os.Getenv("SKYTAP_TEMPLATE_ID"), os.Getenv("SKYTAP_VM_ID"),
 					fmt.Sprintf("name = \"tftest-vm-%d\"", uniqueSuffixVM), "", ``),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("skytap_vm.bar", "name", fmt.Sprintf("tftest-vm-%d", uniqueSuffixVM)),
@@ -133,13 +145,19 @@ func TestAccSkytapVM_Interface(t *testing.T) {
 
 	if os.Getenv("SKYTAP_TEMPLATE_ID") == "" {
 		log.Printf("[WARN] SKYTAP_TEMPLATE_ID required to run skytap_vm_resource acceptance tests. Setting: SKYTAP_TEMPLATE_ID=1473407")
-		os.Setenv("SKYTAP_TEMPLATE_ID", "1473407")
+		err := os.Setenv("SKYTAP_TEMPLATE_ID", "1473407")
+		assert.NoError(t, err)
 	}
 	if os.Getenv("SKYTAP_VM_ID") == "" {
 		log.Printf("[WARN] SKYTAP_VM_ID required to run skytap_vm_resource acceptance tests. Setting: SKYTAP_VM_ID=37865463")
-		os.Setenv("SKYTAP_VM_ID", "37865463")
+		err := os.Setenv("SKYTAP_VM_ID", "37865463")
+		assert.NoError(t, err)
 	}
-
+	newEnvTemplateID := os.Getenv("SKYTAP_TEMPLATE_ID")
+	if os.Getenv("SKYTAP_TEMPLATE_NEW_ENV_ID") != "" {
+		newEnvTemplateID = os.Getenv("SKYTAP_TEMPLATE_NEW_ENV_ID")
+		log.Printf("[DEBUG] SKYTAP_TEMPLATE_NEW_ENV_ID=%s", newEnvTemplateID)
+	}
 	uniqueSuffixEnv := acctest.RandInt()
 	var vm skytap.VM
 
@@ -149,7 +167,7 @@ func TestAccSkytapVM_Interface(t *testing.T) {
 		CheckDestroy: testAccCheckSkytapEnvironmentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSkytapVMConfig_basic(os.Getenv("SKYTAP_TEMPLATE_ID"), uniqueSuffixEnv, `
+				Config: testAccSkytapVMConfig_basic(newEnvTemplateID, uniqueSuffixEnv, `
 					resource "skytap_network" "baz" {
   						"name"        		= "tftest-network-1"
 						"domain"      		= "mydomain.com"
@@ -173,7 +191,7 @@ func TestAccSkytapVM_Interface(t *testing.T) {
 					testAccCheckSkytapInterfaceAttributes("skytap_environment.foo", "skytap_network.baz", &vm, skytap.NICTypeVMXNet3, []string{"192.168.0.10", "192.168.0.11"}, []string{"bloggs-web", "bloggs-web2"}),
 				),
 			}, {
-				Config: testAccSkytapVMConfig_basic(os.Getenv("SKYTAP_TEMPLATE_ID"), uniqueSuffixEnv, `
+				Config: testAccSkytapVMConfig_basic(newEnvTemplateID, uniqueSuffixEnv, `
 					resource "skytap_network" "baz" {
   						"name"        		= "tftest-network-1"
 						"domain"      		= "mydomain.com"
@@ -197,7 +215,7 @@ func TestAccSkytapVM_Interface(t *testing.T) {
 					testAccCheckSkytapInterfaceAttributes("skytap_environment.foo", "skytap_network.baz", &vm, skytap.NICTypeVMXNet3, []string{"192.168.0.20", "192.168.0.21"}, []string{"bloggs-web3", "bloggs-web4"}),
 				),
 			}, {
-				Config: testAccSkytapVMConfig_basic(os.Getenv("SKYTAP_TEMPLATE_ID"), uniqueSuffixEnv, `
+				Config: testAccSkytapVMConfig_basic(newEnvTemplateID, uniqueSuffixEnv, `
 					resource "skytap_network" "baz" {
   						"name"        		= "tftest-network-1"
 						"domain"      		= "mydomain.com"
@@ -224,13 +242,19 @@ func TestAccSkytapVM_PublishedService(t *testing.T) {
 
 	if os.Getenv("SKYTAP_TEMPLATE_ID") == "" {
 		log.Printf("[WARN] SKYTAP_TEMPLATE_ID required to run skytap_vm_resource acceptance tests. Setting: SKYTAP_TEMPLATE_ID=1473407")
-		os.Setenv("SKYTAP_TEMPLATE_ID", "1473407")
+		err := os.Setenv("SKYTAP_TEMPLATE_ID", "1473407")
+		assert.NoError(t, err)
 	}
 	if os.Getenv("SKYTAP_VM_ID") == "" {
 		log.Printf("[WARN] SKYTAP_VM_ID required to run skytap_vm_resource acceptance tests. Setting: SKYTAP_VM_ID=37865463")
-		os.Setenv("SKYTAP_VM_ID", "37865463")
+		err := os.Setenv("SKYTAP_VM_ID", "37865463")
+		assert.NoError(t, err)
 	}
-
+	newEnvTemplateID := os.Getenv("SKYTAP_TEMPLATE_ID")
+	if os.Getenv("SKYTAP_TEMPLATE_NEW_ENV_ID") != "" {
+		newEnvTemplateID = os.Getenv("SKYTAP_TEMPLATE_NEW_ENV_ID")
+		log.Printf("[DEBUG] SKYTAP_TEMPLATE_NEW_ENV_ID=%s", newEnvTemplateID)
+	}
 	uniqueSuffixEnv := acctest.RandInt()
 	var vm skytap.VM
 
@@ -240,7 +264,7 @@ func TestAccSkytapVM_PublishedService(t *testing.T) {
 		CheckDestroy: testAccCheckSkytapEnvironmentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSkytapVMConfig_basic(os.Getenv("SKYTAP_TEMPLATE_ID"), uniqueSuffixEnv, `
+				Config: testAccSkytapVMConfig_basic(newEnvTemplateID, uniqueSuffixEnv, `
 					resource "skytap_network" "baz" {
   						"name"        		= "tftest-network-1"
 						"domain"      		= "mydomain.com"
@@ -264,7 +288,7 @@ func TestAccSkytapVM_PublishedService(t *testing.T) {
 					testAccCheckSkytapPublishedServiceAttributes(&vm, []int{8080, 8081}),
 				),
 			}, {
-				Config: testAccSkytapVMConfig_basic(os.Getenv("SKYTAP_TEMPLATE_ID"), uniqueSuffixEnv, `
+				Config: testAccSkytapVMConfig_basic(newEnvTemplateID, uniqueSuffixEnv, `
 					resource "skytap_network" "baz" {
   						"name"        		= "tftest-network-1"
 						"domain"      		= "mydomain.com"
@@ -288,7 +312,7 @@ func TestAccSkytapVM_PublishedService(t *testing.T) {
 					testAccCheckSkytapPublishedServiceAttributes(&vm, []int{8082, 8083}),
 				),
 			}, {
-				Config: testAccSkytapVMConfig_basic(os.Getenv("SKYTAP_TEMPLATE_ID"), uniqueSuffixEnv, `
+				Config: testAccSkytapVMConfig_basic(newEnvTemplateID, uniqueSuffixEnv, `
 					resource "skytap_network" "baz" {
   						"name"        		= "tftest-network-1"
 						"domain"      		= "mydomain.com"
@@ -309,7 +333,7 @@ func TestAccSkytapVM_PublishedService(t *testing.T) {
 					testAccCheckSkytapPublishedServiceAttributes(&vm, []int{8084}),
 				),
 			}, {
-				Config: testAccSkytapVMConfig_basic(os.Getenv("SKYTAP_TEMPLATE_ID"), uniqueSuffixEnv, `
+				Config: testAccSkytapVMConfig_basic(newEnvTemplateID, uniqueSuffixEnv, `
 					resource "skytap_network" "baz" {
   						"name"        		= "tftest-network-1"
 						"domain"      		= "mydomain.com"
@@ -340,13 +364,19 @@ func TestAccSkytapVM_PublishedServiceBadNic(t *testing.T) {
 
 	if os.Getenv("SKYTAP_TEMPLATE_ID") == "" {
 		log.Printf("[WARN] SKYTAP_TEMPLATE_ID required to run skytap_vm_resource acceptance tests. Setting: SKYTAP_TEMPLATE_ID=1473407")
-		os.Setenv("SKYTAP_TEMPLATE_ID", "1473407")
+		err := os.Setenv("SKYTAP_TEMPLATE_ID", "1473407")
+		assert.NoError(t, err)
 	}
 	if os.Getenv("SKYTAP_VM_ID") == "" {
 		log.Printf("[WARN] SKYTAP_VM_ID required to run skytap_vm_resource acceptance tests. Setting: SKYTAP_VM_ID=37865463")
-		os.Setenv("SKYTAP_VM_ID", "37865463")
+		err := os.Setenv("SKYTAP_VM_ID", "37865463")
+		assert.NoError(t, err)
 	}
-
+	newEnvTemplateID := os.Getenv("SKYTAP_TEMPLATE_ID")
+	if os.Getenv("SKYTAP_TEMPLATE_NEW_ENV_ID") != "" {
+		newEnvTemplateID = os.Getenv("SKYTAP_TEMPLATE_NEW_ENV_ID")
+		log.Printf("[DEBUG] SKYTAP_TEMPLATE_NEW_ENV_ID=%s", newEnvTemplateID)
+	}
 	uniqueSuffixEnv := acctest.RandInt()
 
 	resource.Test(t, resource.TestCase{
@@ -355,7 +385,7 @@ func TestAccSkytapVM_PublishedServiceBadNic(t *testing.T) {
 		CheckDestroy: testAccCheckSkytapEnvironmentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSkytapVMConfig_basic(os.Getenv("SKYTAP_TEMPLATE_ID"), uniqueSuffixEnv, `
+				Config: testAccSkytapVMConfig_basic(newEnvTemplateID, uniqueSuffixEnv, `
 					resource "skytap_network" "baz" {
   						"name"        		= "tftest-network-1"
 						"domain"      		= "mydomain.com"
@@ -377,13 +407,19 @@ func TestAccCasandra(t *testing.T) {
 
 	if os.Getenv("SKYTAP_TEMPLATE_ID") == "" {
 		log.Printf("[WARN] SKYTAP_TEMPLATE_ID required to run skytap_vm_resource acceptance tests. Setting: SKYTAP_TEMPLATE_ID=1473407")
-		os.Setenv("SKYTAP_TEMPLATE_ID", "1473407")
+		err := os.Setenv("SKYTAP_TEMPLATE_ID", "1473407")
+		assert.NoError(t, err)
 	}
 	if os.Getenv("SKYTAP_VM_ID") == "" {
 		log.Printf("[WARN] SKYTAP_VM_ID required to run skytap_vm_resource acceptance tests. Setting: SKYTAP_VM_ID=37865463")
-		os.Setenv("SKYTAP_VM_ID", "37865463")
+		err := os.Setenv("SKYTAP_VM_ID", "37865463")
+		assert.NoError(t, err)
 	}
-
+	newEnvTemplateID := os.Getenv("SKYTAP_TEMPLATE_ID")
+	if os.Getenv("SKYTAP_TEMPLATE_NEW_ENV_ID") != "" {
+		newEnvTemplateID = os.Getenv("SKYTAP_TEMPLATE_NEW_ENV_ID")
+		log.Printf("[DEBUG] SKYTAP_TEMPLATE_NEW_ENV_ID=%s", newEnvTemplateID)
+	}
 	uniqueSuffixEnv := acctest.RandInt()
 
 	resource.Test(t, resource.TestCase{
@@ -392,10 +428,10 @@ func TestAccCasandra(t *testing.T) {
 		CheckDestroy: testAccCheckSkytapEnvironmentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:             testAccSkytapVMConfig_cassandra(os.Getenv("SKYTAP_TEMPLATE_ID"), os.Getenv("SKYTAP_VM_ID"), uniqueSuffixEnv, 22, "", ""),
+				Config:             testAccSkytapVMConfig_cassandra(newEnvTemplateID, os.Getenv("SKYTAP_VM_ID"), uniqueSuffixEnv, 22, "", ""),
 				ExpectNonEmptyPlan: false,
 			}, {
-				Config: testAccSkytapVMConfig_cassandra(os.Getenv("SKYTAP_TEMPLATE_ID"), os.Getenv("SKYTAP_VM_ID"), uniqueSuffixEnv, 23, `"published_service" = {"internal_port" = 8080}`,
+				Config: testAccSkytapVMConfig_cassandra(newEnvTemplateID, os.Getenv("SKYTAP_VM_ID"), uniqueSuffixEnv, 23, `"published_service" = {"internal_port" = 8080}`,
 					`"network_interface" = {
     	              "interface_type" = "vmxnet3"
         	          "network_id"     = "${skytap_network.dev_network.id}"
@@ -419,14 +455,20 @@ func TestAccSkytapVMCPURam_Create(t *testing.T) {
 	//t.Parallel()
 
 	if os.Getenv("SKYTAP_TEMPLATE_ID") == "" {
-		log.Printf("[WARN] SKYTAP_TEMPLATE_ID required to run skytap_vm_resource acceptance tests. Setting: SKYTAP_TEMPLATE_ID=1473407")
-		os.Setenv("SKYTAP_TEMPLATE_ID", "1473407")
+		log.Printf("[WARN] SKYTAP_TEMPLATE_ID required to run skytap_vm_resource acceptance tests. Setting: SKYTAP_TEMPLATE_ID=136409")
+		err := os.Setenv("SKYTAP_TEMPLATE_ID", "136409")
+		assert.NoError(t, err)
 	}
 	if os.Getenv("SKYTAP_VM_ID") == "" {
-		log.Printf("[WARN] SKYTAP_VM_ID required to run skytap_vm_resource acceptance tests. Setting: SKYTAP_VM_ID=37865463")
-		os.Setenv("SKYTAP_VM_ID", "37865463")
+		log.Printf("[WARN] SKYTAP_VM_ID required to run skytap_vm_resource acceptance tests. Setting: SKYTAP_VM_ID=849656")
+		err := os.Setenv("SKYTAP_VM_ID", "849656")
+		assert.NoError(t, err)
 	}
-
+	newEnvTemplateID := os.Getenv("SKYTAP_TEMPLATE_ID")
+	if os.Getenv("SKYTAP_TEMPLATE_NEW_ENV_ID") != "" {
+		newEnvTemplateID = os.Getenv("SKYTAP_TEMPLATE_NEW_ENV_ID")
+		log.Printf("[DEBUG] SKYTAP_TEMPLATE_NEW_ENV_ID=%s", newEnvTemplateID)
+	}
 	uniqueSuffixEnv := acctest.RandInt()
 	var vm skytap.VM
 
@@ -436,16 +478,25 @@ func TestAccSkytapVMCPURam_Create(t *testing.T) {
 		CheckDestroy: testAccCheckSkytapEnvironmentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSkytapVMConfig_basic(os.Getenv("SKYTAP_TEMPLATE_ID"), uniqueSuffixEnv, "", os.Getenv("SKYTAP_TEMPLATE_ID"), os.Getenv("SKYTAP_VM_ID"), "", "",
-					`"cpus" = 12`),
+				Config: testAccSkytapVMConfig_basic(newEnvTemplateID, uniqueSuffixEnv, "", os.Getenv("SKYTAP_TEMPLATE_ID"), os.Getenv("SKYTAP_VM_ID"), "", "",
+					``),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSkytapVMExists("skytap_environment.foo", "skytap_vm.bar", &vm),
-					resource.TestCheckResourceAttr("skytap_vm.bar", "cpus", "12"),
-					testAccCheckSkytapVMCPU(t, &vm, 12),
+					resource.TestCheckResourceAttrSet("skytap_vm.bar", "cpus"),
+					resource.TestCheckResourceAttrSet("skytap_vm.bar", "ram"),
 				),
 			},
 			{
-				Config: testAccSkytapVMConfig_basic(os.Getenv("SKYTAP_TEMPLATE_ID"), uniqueSuffixEnv, "", os.Getenv("SKYTAP_TEMPLATE_ID"), os.Getenv("SKYTAP_VM_ID"), "", "",
+				Config: testAccSkytapVMConfig_basic(newEnvTemplateID, uniqueSuffixEnv, "", os.Getenv("SKYTAP_TEMPLATE_ID"), os.Getenv("SKYTAP_VM_ID"), "", "",
+					`"cpus" = 8`),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSkytapVMExists("skytap_environment.foo", "skytap_vm.bar", &vm),
+					resource.TestCheckResourceAttr("skytap_vm.bar", "cpus", "8"),
+					testAccCheckSkytapVMCPU(t, &vm, 8),
+				),
+			},
+			{
+				Config: testAccSkytapVMConfig_basic(newEnvTemplateID, uniqueSuffixEnv, "", os.Getenv("SKYTAP_TEMPLATE_ID"), os.Getenv("SKYTAP_VM_ID"), "", "",
 					`"ram" = 8192`),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSkytapVMExists("skytap_environment.foo", "skytap_vm.bar", &vm),
@@ -454,14 +505,14 @@ func TestAccSkytapVMCPURam_Create(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccSkytapVMConfig_basic(os.Getenv("SKYTAP_TEMPLATE_ID"), uniqueSuffixEnv, "", os.Getenv("SKYTAP_TEMPLATE_ID"), os.Getenv("SKYTAP_VM_ID"), "", "",
-					`"cpus" = 12
+				Config: testAccSkytapVMConfig_basic(newEnvTemplateID, uniqueSuffixEnv, "", os.Getenv("SKYTAP_TEMPLATE_ID"), os.Getenv("SKYTAP_VM_ID"), "", "",
+					`"cpus" = 8
 									"ram" = 8192`),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSkytapVMExists("skytap_environment.foo", "skytap_vm.bar", &vm),
-					resource.TestCheckResourceAttr("skytap_vm.bar", "cpus", "12"),
+					resource.TestCheckResourceAttr("skytap_vm.bar", "cpus", "8"),
 					resource.TestCheckResourceAttr("skytap_vm.bar", "ram", "8192"),
-					testAccCheckSkytapVMCPU(t, &vm, 12),
+					testAccCheckSkytapVMCPU(t, &vm, 8),
 					testAccCheckSkytapVMRAM(t, &vm, 8192),
 				),
 			},
@@ -474,13 +525,19 @@ func TestAccSkytapVMCPU_Invalid(t *testing.T) {
 
 	if os.Getenv("SKYTAP_TEMPLATE_ID") == "" {
 		log.Printf("[WARN] SKYTAP_TEMPLATE_ID required to run skytap_vm_resource acceptance tests. Setting: SKYTAP_TEMPLATE_ID=1473407")
-		os.Setenv("SKYTAP_TEMPLATE_ID", "1473407")
+		err := os.Setenv("SKYTAP_TEMPLATE_ID", "1473407")
+		assert.NoError(t, err)
 	}
 	if os.Getenv("SKYTAP_VM_ID") == "" {
 		log.Printf("[WARN] SKYTAP_VM_ID required to run skytap_vm_resource acceptance tests. Setting: SKYTAP_VM_ID=37865463")
-		os.Setenv("SKYTAP_VM_ID", "37865463")
+		err := os.Setenv("SKYTAP_VM_ID", "37865463")
+		assert.NoError(t, err)
 	}
-
+	newEnvTemplateID := os.Getenv("SKYTAP_TEMPLATE_ID")
+	if os.Getenv("SKYTAP_TEMPLATE_NEW_ENV_ID") != "" {
+		newEnvTemplateID = os.Getenv("SKYTAP_TEMPLATE_NEW_ENV_ID")
+		log.Printf("[DEBUG] SKYTAP_TEMPLATE_NEW_ENV_ID=%s", newEnvTemplateID)
+	}
 	uniqueSuffixEnv := acctest.RandInt()
 
 	resource.Test(t, resource.TestCase{
@@ -489,7 +546,7 @@ func TestAccSkytapVMCPU_Invalid(t *testing.T) {
 		CheckDestroy: testAccCheckSkytapEnvironmentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSkytapVMConfig_basic(os.Getenv("SKYTAP_TEMPLATE_ID"), uniqueSuffixEnv, "", os.Getenv("SKYTAP_TEMPLATE_ID"), os.Getenv("SKYTAP_VM_ID"), "", "",
+				Config: testAccSkytapVMConfig_basic(newEnvTemplateID, uniqueSuffixEnv, "", os.Getenv("SKYTAP_TEMPLATE_ID"), os.Getenv("SKYTAP_VM_ID"), "", "",
 					`"cpus" = 121
 									"ram" = 819000000002`),
 				ExpectError: regexp.MustCompile(`config is invalid: 2 problems:*`),
@@ -503,13 +560,19 @@ func TestAccSkytapVMCPU_OutOfRange(t *testing.T) {
 
 	if os.Getenv("SKYTAP_TEMPLATE_ID") == "" {
 		log.Printf("[WARN] SKYTAP_TEMPLATE_ID required to run skytap_vm_resource acceptance tests. Setting: SKYTAP_TEMPLATE_ID=136409")
-		os.Setenv("SKYTAP_TEMPLATE_ID", "136409")
+		err := os.Setenv("SKYTAP_TEMPLATE_ID", "136409")
+		assert.NoError(t, err)
 	}
 	if os.Getenv("SKYTAP_VM_ID") == "" {
 		log.Printf("[WARN] SKYTAP_VM_ID required to run skytap_vm_resource acceptance tests. Setting: SKYTAP_VM_ID=849656")
-		os.Setenv("SKYTAP_VM_ID", "849656")
+		err := os.Setenv("SKYTAP_VM_ID", "849656")
+		assert.NoError(t, err)
 	}
-
+	newEnvTemplateID := os.Getenv("SKYTAP_TEMPLATE_ID")
+	if os.Getenv("SKYTAP_TEMPLATE_NEW_ENV_ID") != "" {
+		newEnvTemplateID = os.Getenv("SKYTAP_TEMPLATE_NEW_ENV_ID")
+		log.Printf("[DEBUG] SKYTAP_TEMPLATE_NEW_ENV_ID=%s", newEnvTemplateID)
+	}
 	uniqueSuffixEnv := acctest.RandInt()
 
 	resource.Test(t, resource.TestCase{
@@ -518,10 +581,105 @@ func TestAccSkytapVMCPU_OutOfRange(t *testing.T) {
 		CheckDestroy: testAccCheckSkytapEnvironmentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSkytapVMConfig_basic(os.Getenv("SKYTAP_TEMPLATE_ID"), uniqueSuffixEnv, "", os.Getenv("SKYTAP_TEMPLATE_ID"), os.Getenv("SKYTAP_VM_ID"), "", "",
+				Config: testAccSkytapVMConfig_basic(newEnvTemplateID, uniqueSuffixEnv, "", os.Getenv("SKYTAP_TEMPLATE_ID"), os.Getenv("SKYTAP_VM_ID"), "", "",
 					`"cpus" = 12
 									"ram" = 131072`),
-				ExpectError: regexp.MustCompile(`the 'CPUs' argument has been assigned 12 which is more than the maximum allowed \(8\) as defined by this VM`),
+				ExpectError: regexp.MustCompile(`the 'cpus' argument has been assigned 12 which is more than the maximum allowed \(8\) as defined by this VM`),
+			},
+		},
+	})
+}
+
+func TestAccSkytapVMDisks_Create(t *testing.T) {
+	//t.Parallel()
+
+	if os.Getenv("SKYTAP_TEMPLATE_ID") == "" {
+		log.Printf("[WARN] SKYTAP_TEMPLATE_ID required to run skytap_vm_resource acceptance tests. Setting: SKYTAP_TEMPLATE_ID=136409")
+		err := os.Setenv("SKYTAP_TEMPLATE_ID", "136409")
+		assert.NoError(t, err)
+	}
+	if os.Getenv("SKYTAP_VM_ID") == "" {
+		log.Printf("[WARN] SKYTAP_VM_ID required to run skytap_vm_resource acceptance tests. Setting: SKYTAP_VM_ID=849656")
+		err := os.Setenv("SKYTAP_VM_ID", "849656")
+		assert.NoError(t, err)
+	}
+	newEnvTemplateID := os.Getenv("SKYTAP_TEMPLATE_ID")
+	if os.Getenv("SKYTAP_TEMPLATE_NEW_ENV_ID") != "" {
+		newEnvTemplateID = os.Getenv("SKYTAP_TEMPLATE_NEW_ENV_ID")
+		log.Printf("[DEBUG] SKYTAP_TEMPLATE_NEW_ENV_ID=%s", newEnvTemplateID)
+	}
+	uniqueSuffixEnv := acctest.RandInt()
+	var vm skytap.VM
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckSkytapEnvironmentDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSkytapVMConfig_basic(newEnvTemplateID, uniqueSuffixEnv, "", os.Getenv("SKYTAP_TEMPLATE_ID"), os.Getenv("SKYTAP_VM_ID"), "", "",
+					`"cpus" = 8
+									"ram" = 8192
+									"disk" = {
+										"size" = 2048
+										"name" = "smaller"  
+									}
+									"disk" = {
+										"size" = 2048
+										"name" = "smaller2"  
+									}
+									"disk" = {
+										"size" = 2049
+										"name" = "bigger"
+									}`),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSkytapVMExists("skytap_environment.foo", "skytap_vm.bar", &vm),
+					testAccCheckSkytapVMDiskResource(t, "skytap_vm.bar"),
+					testAccCheckSkytapVMDisks(t, &vm, []int{2048, 2048, 2049}),
+				),
+			},
+		},
+	})
+}
+
+func TestAccSkytapVMDisk_Invalid(t *testing.T) {
+	//t.Parallel()
+
+	if os.Getenv("SKYTAP_TEMPLATE_ID") == "" {
+		log.Printf("[WARN] SKYTAP_TEMPLATE_ID required to run skytap_vm_resource acceptance tests. Setting: SKYTAP_TEMPLATE_ID=1473407")
+		err := os.Setenv("SKYTAP_TEMPLATE_ID", "1473407")
+		assert.NoError(t, err)
+	}
+	if os.Getenv("SKYTAP_VM_ID") == "" {
+		log.Printf("[WARN] SKYTAP_VM_ID required to run skytap_vm_resource acceptance tests. Setting: SKYTAP_VM_ID=37865463")
+		err := os.Setenv("SKYTAP_VM_ID", "37865463")
+		assert.NoError(t, err)
+	}
+	newEnvTemplateID := os.Getenv("SKYTAP_TEMPLATE_ID")
+	if os.Getenv("SKYTAP_TEMPLATE_NEW_ENV_ID") != "" {
+		newEnvTemplateID = os.Getenv("SKYTAP_TEMPLATE_NEW_ENV_ID")
+		log.Printf("[DEBUG] SKYTAP_TEMPLATE_NEW_ENV_ID=%s", newEnvTemplateID)
+	}
+	uniqueSuffixEnv := acctest.RandInt()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckSkytapEnvironmentDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSkytapVMConfig_basic(newEnvTemplateID, uniqueSuffixEnv, "", os.Getenv("SKYTAP_TEMPLATE_ID"), os.Getenv("SKYTAP_VM_ID"), "", "",
+					`"disk" = {
+										"size" = 2047
+									}`),
+				ExpectError: regexp.MustCompile(`config is invalid: skytap_vm.bar: expected disk.0.size to be in the range \(2048 - 2096128\), got 2047`),
+			},
+			{
+				Config: testAccSkytapVMConfig_basic(newEnvTemplateID, uniqueSuffixEnv, "", os.Getenv("SKYTAP_TEMPLATE_ID"), os.Getenv("SKYTAP_VM_ID"), "", "",
+					`"disk" = {
+										"size" = 2096129
+									}`),
+				ExpectError: regexp.MustCompile(`config is invalid: skytap_vm.bar: expected disk.0.size to be in the range \(2048 - 2096128\), got 2096129`),
 			},
 		},
 	})
@@ -776,6 +934,33 @@ func testAccCheckSkytapVMCPU(t *testing.T, vm *skytap.VM, cpus int) resource.Tes
 func testAccCheckSkytapVMRAM(t *testing.T, vm *skytap.VM, ram int) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		assert.Equal(t, ram, *vm.Hardware.RAM, "ram")
+		return nil
+	}
+}
+
+func testAccCheckSkytapVMDiskResource(t *testing.T, name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rsVM, err := getResource(s, name)
+		assert.NotNil(t, rsVM)
+		if err != nil {
+			return err
+		}
+		assert.Equal(t, "3", rsVM.Primary.Attributes["disk.#"])
+		return nil
+	}
+}
+
+func testAccCheckSkytapVMDisks(t *testing.T, vm *skytap.VM, sizes []int) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		sort.Slice(vm.Hardware.Disks, func(i, j int) bool {
+			return *vm.Hardware.Disks[i].Size < *vm.Hardware.Disks[j].Size
+		})
+		ok := assert.Equal(t, len(sizes)+1, len(vm.Hardware.Disks)) // os disk means +1
+		if ok {
+			for idx, size := range sizes {
+				assert.Equal(t, size, *vm.Hardware.Disks[idx].Size, "disk size")
+			}
+		}
 		return nil
 	}
 }

--- a/skytap/structures.go
+++ b/skytap/structures.go
@@ -45,3 +45,51 @@ func flattenPublishedService(v skytap.PublishedService) map[string]interface{} {
 	result["external_port"] = *v.ExternalPort
 	return result
 }
+
+func flattenDisks(disks []skytap.Disk, diskResource *schema.Set) *schema.Set {
+	results := make([]interface{}, 0)
+
+	firstTime := make(map[int][]string)
+	otherTimes := make(map[string]string)
+	if diskResource != nil {
+		for _, v := range diskResource.List() {
+			values := v.(map[string]interface{})
+			id := values["id"].(string)
+			name := values["name"].(string)
+			if id == "" {
+				size := values["size"].(int)
+				if len(firstTime[size]) == 0 {
+					firstTime[size] = make([]string, 0)
+				}
+				firstTime[size] = append(firstTime[size], name)
+			} else {
+				otherTimes[id] = name
+			}
+		}
+	}
+	for _, v := range disks {
+		// ignore os disk for now
+		if "0" != *v.LUN {
+			results = append(results, flattenDisk(v, firstTime, otherTimes))
+		}
+	}
+
+	return schema.NewSet(diskHash, results)
+}
+
+func flattenDisk(v skytap.Disk, firstTime map[int][]string, otherTimes map[string]string) map[string]interface{} {
+	result := make(map[string]interface{})
+	size := *v.Size
+	result["id"] = *v.ID
+	result["size"] = size
+	result["type"] = *v.Type
+	result["controller"] = *v.Controller
+	result["lun"] = *v.LUN
+	if len(otherTimes) > 0 {
+		result["name"] = otherTimes[*v.ID]
+	} else if len(firstTime[size]) > 0 {
+		result["name"] = firstTime[size][0]
+		firstTime[size] = append(firstTime[size][1:])
+	}
+	return result
+}

--- a/skytap/testdata/disks.json
+++ b/skytap/testdata/disks.json
@@ -1,0 +1,23 @@
+[
+  {
+    "id": "disk-1-1-scsi-0-0",
+    "size": 5120,
+    "type": "SCSI",
+    "controller": "0",
+    "lun": "0"
+  },
+  {
+    "id": "disk-1-1-scsi-0-1",
+    "size": 5121,
+    "type": "SCSI",
+    "controller": "0",
+    "lun": "1"
+  },
+  {
+    "id": "disk-1-1-scsi-0-2",
+    "size": 5120,
+    "type": "SCSI",
+    "controller": "0",
+    "lun": "2"
+  }
+]

--- a/vendor/github.com/skytap/skytap-sdk-go/skytap/vm.go
+++ b/vendor/github.com/skytap/skytap-sdk-go/skytap/vm.go
@@ -187,9 +187,20 @@ type UpdateVMRequest struct {
 	Hardware *UpdateHardware `json:"hardware,omitempty"`
 }
 
+// UpdateHardware describes the update data to update the VM cpu, ram and disks
 type UpdateHardware struct {
-	CPUs *int `json:"cpus,omitempty"`
-	RAM  *int `json:"ram,omitempty"`
+	CPUs     *int      `json:"cpus,omitempty"`
+	RAM      *int      `json:"ram,omitempty"`
+	NewDisks *NewDisks `json:"disks,omitempty"`
+}
+
+// NewDisks defines a list of new disks via the sizes
+type NewDisks struct {
+	Sizes []int `json:"new,omitempty"`
+}
+
+// RemoveDisk defines the disk to remove
+type RemoveDisk struct {
 }
 
 // VMListResult is the listing request specific struct

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -757,10 +757,10 @@
 			"revisionTime": "2018-09-10T08:07:58Z"
 		},
 		{
-			"checksumSHA1": "zClTwMn8sRaxBpoTtBYc7E/l0zI=",
+			"checksumSHA1": "t1MYgXEbwh+hZ6L7wKZLO5qp8GQ=",
 			"path": "github.com/skytap/skytap-sdk-go/skytap",
-			"revision": "c67aa95f7108f013e89ab094d7c0e44170e52400",
-			"revisionTime": "2018-12-13T13:32:23Z",
+			"revision": "4c00c98256a429e9bfa6548d35e2ffa9911d5b54",
+			"revisionTime": "2018-12-17T14:47:15Z",
 			"version": "v2",
 			"versionExact": "v2"
 		},

--- a/website/docs/r/vm.html.md
+++ b/website/docs/r/vm.html.md
@@ -41,6 +41,14 @@ The following arguments are supported:
 * `name` - (Optional, Computed) User-defined name. Limited to 100 characters. 
 * `cpus` - (Optional, Computed, ForceNew) Number of CPUs allocated to this virtual machine. Valid range is 1 to 12. Maximum limit depends on the `max_cpus` setting.
 * `ram` - (Optional, Computed, ForceNew) Amount of RAM allocated to this VM. Valid range is 256 and 131,072 (MB). Maximum limit depends on `max_ram` setting.
+* `disk` - (Optional, ForceNew) Array of virtual disks within the VM. The disk size is in MiB; it will be converted to GiB in the Skytap UI. The maximum disk size is 2,096,128 MiB (1.999 TiB).
+
+  * `name` - (Required) A unique name for the disk.
+  * `id` - (Computed) The ID for the disk.
+  * `size` - (Required, Force New) Specify the size of the disk. The new disk’s size should be provided in MiB. The minimum disk size is 2048 MiB; the maximum is 2096128 MiB (1.999 TiB).
+  * `type` - (Computed) The type of disk.
+  * `controller` - (Computed) The disk controller.
+  * `lun` - (Computed) The logical unit number of the disk (LUN).
 
 
   ~> **NOTE:** The name will be truncated to 33 UTF-8 characters after saving. If a name is not provided then the source VM's name will be used.


### PR DESCRIPTION
Add new disk element to the VM resource. 
The allows the ability to add disks to the VM.
It is a Force New at this stage.
Refactor to make separation between create and update flows cleaner.

Note: rebased on feature/cpu because it is not possible to merge to master at this time.