### PR TITLE
#2 Add OS disk resizing to VM resource

### DIFF
--- a/skytap/resource_skytap_vm_hardware_test.go
+++ b/skytap/resource_skytap_vm_hardware_test.go
@@ -622,7 +622,7 @@ func TestAccSkytapVMDisk_OSChangeAfter(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSkytapVMExists("skytap_environment.foo", "skytap_vm.bar", &vmUpdated),
 					testAccCheckSkytapVMUpdated(t, &vm, &vmUpdated),
-					resource.TestCheckResourceAttr("skytap_vm.bar", "os_disk_size", "4096"),
+					resource.TestCheckResourceAttr("skytap_vm.bar", "os_disk_size", "30721"),
 				),
 			},
 		},

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -757,10 +757,10 @@
 			"revisionTime": "2018-09-10T08:07:58Z"
 		},
 		{
-			"checksumSHA1": "gYsbXYH/+pA9dEnt8xgcHJjQ1bg=",
+			"checksumSHA1": "TnBhDsG4ik4XQ7wxYg9U4HZnryU=",
 			"path": "github.com/skytap/skytap-sdk-go/skytap",
-			"revision": "c1469baad65b7ea0cb2a213e4e8a9bec592840bf",
-			"revisionTime": "2018-12-20T10:54:03Z"
+			"revision": "127a79d5831c21bb1c89d4bffce9147510756a73",
+			"revisionTime": "2018-12-20T13:52:58Z"
 		},
 		{
 			"checksumSHA1": "c6pbpF7eowwO59phRTpF8cQ80Z0=",


### PR DESCRIPTION
A new element called `os_disk_size` has been added to the VM resource. It allows the size of the disk to be specified. It validates that the disk is not shrunk
Add missing validation on CPU and RAM for update phase. Add two computed elements to facilitate this: `max_cpus` and `max_ram`.
Fixed a bug with the last PR #15 - by adding a missing object DiskIdentification in the request.