### PR TITLE
#7 Add map for published service ports and IPs

### DIFF
--- a/skytap/config.go
+++ b/skytap/config.go
@@ -24,7 +24,8 @@ type SkytapClient struct {
 	vmsClient               skytap.VMsService
 	interfacesClient        skytap.InterfacesService
 	publishedServicesClient skytap.PublishedServicesService
-	names                   interface{}
+	vmDisks                 interface{}
+	vmNetworks              interface{}
 }
 
 // Client creates a SkytapClient client

--- a/skytap/resource_skytap_vm_test.go
+++ b/skytap/resource_skytap_vm_test.go
@@ -759,11 +759,10 @@ func getVM(rs *terraform.ResourceState, environmentID string) (*skytap.VM, error
 }
 
 func testAccCheckSkytapVMRunning(vm *skytap.VM) resource.TestCheckFunc {
+	if os.Getenv("SKYTAP_DISABLE_FORCE_RUNNING") == "" {
+		return resource.TestCheckResourceAttr("skytap_vm.bar", "runstate", string(skytap.VMRunstateRunning))
+	}
 	return func(s *terraform.State) error {
-		resource.TestCheckResourceAttr("skytap_vm.bar", "runstate", string(skytap.VMRunstateRunning))
-		if skytap.VMRunstateRunning != *vm.Runstate && os.Getenv("SKYTAP_DISABLE_FORCE_RUNNING") == "" {
-			return fmt.Errorf("vm (%s) is not running as expected", *vm.ID)
-		}
 		return nil
 	}
 }

--- a/skytap/resource_skytap_vm_test.go
+++ b/skytap/resource_skytap_vm_test.go
@@ -501,7 +501,11 @@ func TestAccCasandra(t *testing.T) {
 				Config:             testAccSkytapVMConfig_cassandra(newEnvTemplateID, os.Getenv("SKYTAP_TEMPLATE_ID"), os.Getenv("SKYTAP_VM_ID"), uniqueSuffixEnv, 22, "", ""),
 				ExpectNonEmptyPlan: false,
 			}, {
-				Config: testAccSkytapVMConfig_cassandra(newEnvTemplateID, os.Getenv("SKYTAP_TEMPLATE_ID"), os.Getenv("SKYTAP_VM_ID"), uniqueSuffixEnv, 23, `"published_service" = {"internal_port" = 8080}`,
+				Config: testAccSkytapVMConfig_cassandra(newEnvTemplateID, os.Getenv("SKYTAP_TEMPLATE_ID"), os.Getenv("SKYTAP_VM_ID"), uniqueSuffixEnv, 23,
+					`"published_service" = {
+						name = "web-internal"
+						"internal_port" = 8080
+					}`,
 					`"network_interface" = {
     	              "interface_type" = "vmxnet3"
         	          "network_id"     = "${skytap_network.dev_network.id}"

--- a/skytap/resource_skytap_vm_test.go
+++ b/skytap/resource_skytap_vm_test.go
@@ -188,7 +188,7 @@ func TestAccSkytapVM_Interface(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSkytapVMExists("skytap_environment.foo", "skytap_vm.bar", &vm),
 					testAccCheckSkytapInterfacesExists("skytap_environment.foo", "skytap_vm.bar", "skytap_network.baz", 2),
-					testAccCheckSkytapInterfaceAttributes("skytap_environment.foo", "skytap_network.baz", &vm, skytap.NICTypeVMXNet3, []string{"192.168.0.10", "192.168.0.11"}, []string{"bloggs-web", "bloggs-web2"}),
+					testAccCheckSkytapInterfaceAttributes(t, "skytap_environment.foo", "skytap_network.baz", &vm, skytap.NICTypeVMXNet3, []string{"192.168.0.10", "192.168.0.11"}, []string{"bloggs-web", "bloggs-web2"}),
 				),
 			}, {
 				Config: testAccSkytapVMConfig_basic(newEnvTemplateID, uniqueSuffixEnv, `
@@ -212,7 +212,7 @@ func TestAccSkytapVM_Interface(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSkytapVMExists("skytap_environment.foo", "skytap_vm.bar", &vm),
 					testAccCheckSkytapInterfacesExists("skytap_environment.foo", "skytap_vm.bar", "skytap_network.baz", 2),
-					testAccCheckSkytapInterfaceAttributes("skytap_environment.foo", "skytap_network.baz", &vm, skytap.NICTypeVMXNet3, []string{"192.168.0.20", "192.168.0.21"}, []string{"bloggs-web3", "bloggs-web4"}),
+					testAccCheckSkytapInterfaceAttributes(t, "skytap_environment.foo", "skytap_network.baz", &vm, skytap.NICTypeVMXNet3, []string{"192.168.0.20", "192.168.0.21"}, []string{"bloggs-web3", "bloggs-web4"}),
 				),
 			}, {
 				Config: testAccSkytapVMConfig_basic(newEnvTemplateID, uniqueSuffixEnv, `
@@ -230,7 +230,7 @@ func TestAccSkytapVM_Interface(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSkytapVMExists("skytap_environment.foo", "skytap_vm.bar", &vm),
 					testAccCheckSkytapInterfacesExists("skytap_environment.foo", "skytap_vm.bar", "skytap_network.baz", 1),
-					testAccCheckSkytapInterfaceAttributes("skytap_environment.foo", "skytap_network.baz", &vm, skytap.NICTypeVMXNet3, []string{"192.168.0.22"}, []string{"bloggs-web5"}),
+					testAccCheckSkytapInterfaceAttributes(t, "skytap_environment.foo", "skytap_network.baz", &vm, skytap.NICTypeVMXNet3, []string{"192.168.0.22"}, []string{"bloggs-web5"}),
 				),
 			},
 		},
@@ -241,13 +241,13 @@ func TestAccSkytapVM_PublishedService(t *testing.T) {
 	//t.Parallel()
 
 	if os.Getenv("SKYTAP_TEMPLATE_ID") == "" {
-		log.Printf("[WARN] SKYTAP_TEMPLATE_ID required to run skytap_vm_resource acceptance tests. Setting: SKYTAP_TEMPLATE_ID=1473407")
-		err := os.Setenv("SKYTAP_TEMPLATE_ID", "1473407")
+		log.Printf("[WARN] SKYTAP_TEMPLATE_ID required to run skytap_vm_resource acceptance tests. Setting: SKYTAP_TEMPLATE_ID=136409")
+		err := os.Setenv("SKYTAP_TEMPLATE_ID", "136409")
 		assert.NoError(t, err)
 	}
 	if os.Getenv("SKYTAP_VM_ID") == "" {
-		log.Printf("[WARN] SKYTAP_VM_ID required to run skytap_vm_resource acceptance tests. Setting: SKYTAP_VM_ID=37865463")
-		err := os.Setenv("SKYTAP_VM_ID", "37865463")
+		log.Printf("[WARN] SKYTAP_VM_ID required to run skytap_vm_resource acceptance tests. Setting: SKYTAP_VM_ID=849656")
+		err := os.Setenv("SKYTAP_VM_ID", "849656")
 		assert.NoError(t, err)
 	}
 	newEnvTemplateID := os.Getenv("SKYTAP_TEMPLATE_ID")
@@ -276,9 +276,11 @@ func TestAccSkytapVM_PublishedService(t *testing.T) {
 						ip = "192.168.0.10"
 						hostname = "bloggs-web"
 						published_service {
+							name = "web0"
 							internal_port = 8080
 						}
 						published_service {
+							name = "web1"
 							internal_port = 8081
 						}
                   	}`, ``),
@@ -300,9 +302,11 @@ func TestAccSkytapVM_PublishedService(t *testing.T) {
 						ip = "192.168.0.10"
 						hostname = "bloggs-web"
 						published_service {
+							name = "web2"
 							internal_port = 8082
 						}
 						published_service {
+							name = "web3"
 							internal_port = 8083
 						}
                   	}`, ``),
@@ -324,6 +328,7 @@ func TestAccSkytapVM_PublishedService(t *testing.T) {
 						ip = "192.168.0.10"
 						hostname = "bloggs-web"
 						published_service {
+							name = "web4"
 							internal_port = 8084
 						}
                   	}`, ``),
@@ -345,6 +350,7 @@ func TestAccSkytapVM_PublishedService(t *testing.T) {
 						ip = "192.168.0.10"
 						hostname = "bloggs-web"
 						published_service {
+							name = "web4"
 							internal_port = 8084
 						}
                   	}`, ``),
@@ -403,6 +409,70 @@ func TestAccSkytapVM_PublishedServiceBadNic(t *testing.T) {
 	})
 }
 
+func TestAccExternalPorts(t *testing.T) {
+
+	if os.Getenv("SKYTAP_TEMPLATE_ID") == "" {
+		log.Printf("[WARN] SKYTAP_TEMPLATE_ID required to run skytap_vm_resource acceptance tests. Setting: SKYTAP_TEMPLATE_ID=1473407")
+		err := os.Setenv("SKYTAP_TEMPLATE_ID", "1473407")
+		assert.NoError(t, err)
+	}
+	if os.Getenv("SKYTAP_VM_ID") == "" {
+		log.Printf("[WARN] SKYTAP_VM_ID required to run skytap_vm_resource acceptance tests. Setting: SKYTAP_VM_ID=37865463")
+		err := os.Setenv("SKYTAP_VM_ID", "37865463")
+		assert.NoError(t, err)
+	}
+	newEnvTemplateID := os.Getenv("SKYTAP_TEMPLATE_ID")
+	if os.Getenv("SKYTAP_TEMPLATE_NEW_ENV_ID") != "" {
+		newEnvTemplateID = os.Getenv("SKYTAP_TEMPLATE_NEW_ENV_ID")
+		log.Printf("[DEBUG] SKYTAP_TEMPLATE_NEW_ENV_ID=%s", newEnvTemplateID)
+	}
+
+	uniqueSuffixEnv := acctest.RandInt()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckSkytapEnvironmentDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSkytapVMConfig_cassandra(newEnvTemplateID, os.Getenv("SKYTAP_TEMPLATE_ID"), os.Getenv("SKYTAP_VM_ID"), uniqueSuffixEnv, 23,
+					`"published_service" = {"name" = "web-internal" "internal_port" = 8080}`,
+					`"network_interface" = {
+    	              "interface_type" = "vmxnet3"
+        	          "network_id"     = "${skytap_network.dev_network.id}"
+        	          "ip"         = "10.0.3.2"
+                      "hostname" = "myhost2"
+
+        	          "published_service" = {
+						"name" = "ssh"
+          	            "internal_port" = 22
+        	          }
+        	          "published_service" = {
+						"name" = "web"
+          	            "internal_port" = 80
+        	          }
+      	            }`),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSkytapExternalPorts(t, "skytap_vm.cassandra1", "4"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckSkytapExternalPorts(t *testing.T, vmName string, count string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rsVM, err := getResource(s, vmName)
+		if err != nil {
+			return err
+		}
+		assert.Equal(t, count, rsVM.Primary.Attributes["service_ports.%"], "empty map entry")
+		assert.Equal(t, count, rsVM.Primary.Attributes["service_ips.%"], "empty map entry")
+
+		return nil
+	}
+}
+
 func TestAccCasandra(t *testing.T) {
 
 	if os.Getenv("SKYTAP_TEMPLATE_ID") == "" {
@@ -439,9 +509,11 @@ func TestAccCasandra(t *testing.T) {
                       "hostname" = "myhost2"
 
         	          "published_service" = {
+						name = "ssh"
           	            "internal_port" = 22
         	          }
         	          "published_service" = {
+						name = "web"
           	            "internal_port" = 80
         	          }
       	            }`),
@@ -479,6 +551,7 @@ func testAccSkytapVMConfig_cassandra(envTemplateID string, templateID string, vm
         "hostname" = "myhost"
 
         "published_service" = {
+          "name" = "service"
           "internal_port" = %d
         }
         %s
@@ -520,7 +593,7 @@ func testAccCheckSkytapPublishedServiceAttributes(vm *skytap.VM, ports []int) re
 	}
 }
 
-func testAccCheckSkytapInterfaceAttributes(environmentName string, networkName string, vm *skytap.VM, nicType skytap.NICType, ips []string, hostnames []string) resource.TestCheckFunc {
+func testAccCheckSkytapInterfaceAttributes(t *testing.T, environmentName string, networkName string, vm *skytap.VM, nicType skytap.NICType, ips []string, hostnames []string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 
 		rsEnvironment, err := getResource(s, environmentName)
@@ -562,6 +635,7 @@ func testAccCheckSkytapInterfaceAttributes(environmentName string, networkName s
 			if *adapter.NetworkID != *net.ID {
 				return fmt.Errorf("the interface network IDs (%s) are not configured as expected (%s)", *adapter.NetworkID, *net.ID)
 			}
+			assert.NotNil(t, adapter.ID)
 		}
 		return nil
 	}

--- a/skytap/structures_test.go
+++ b/skytap/structures_test.go
@@ -12,70 +12,20 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-const exampleInterfaceListResponse = `[
-    {
-        "id": "nic-20246343-38367563-0",
-        "ip": "192.168.0.1",
-        "hostname": "wins2016s",
-        "mac": "00:50:56:11:7D:D9",
-        "services_count": 0,
-        "services": [],
-        "public_ips_count": 0,
-        "public_ips": [],
-        "vm_id": "37527239",
-        "vm_name": "Windows Server 2016 Standard",
-        "status": "Running",
-        "network_id": "23917287",
-        "network_name": "tftest-network-1",
-        "network_url": "https://cloud.skytap.com/v2/configurations/40064014/networks/23917287",
-        "network_type": "automatic",
-        "network_subnet": "192.168.0.0/16",
-        "nic_type": "vmxnet3",
-        "secondary_ips": [],
-        "public_ip_attachments": []
-    },
-    {
-        "id": "nic-20246343-38367563-5",
-        "ip": "192.168.0.2",
-        "hostname": "wins2016s2",
-        "mac": "00:50:56:07:40:3F",
-        "services_count": 0,
-        "services": [],
-        "public_ips_count": 0,
-        "public_ips": [],
-        "vm_id": "37527239",
-        "vm_name": "Windows Server 2016 Standard",
-        "status": "Running",
-        "network_id": "23917287",
-        "nic_type": "e1000",
-        "secondary_ips": [],
-        "public_ip_attachments": []
-    }
-]`
-
-const examplePublishedServiceListResponse = `[
-    {
-        "id": "8080",
-        "internal_port": 8080,
-        "external_ip": "services-uswest.skytap.com",
-        "external_port": 26160
-    },
-    {
-        "id": "8081",
-        "internal_port": 8081,
-        "external_ip": "services-useast.skytap.com",
-        "external_port": 17785
-    }
-]`
-
 func TestFlattenInterfaces(t *testing.T) {
+
+	response := string(readTestFile(t, "vm_interface_response.json"))
 
 	expected := make(map[string][]string)
 	expected["ip"] = []string{"192.168.0.1", "192.168.0.2"}
 	expected["hostname"] = []string{"wins2016s", "wins2016s2"}
+	expected["id"] = []string{"nic-20246343-38367563-0", "nic-20246343-38367563-5"}
 
 	var interfaces []skytap.Interface
-	json.Unmarshal([]byte(exampleInterfaceListResponse), &interfaces)
+	err := json.Unmarshal([]byte(response), &interfaces)
+	if err != nil {
+		t.Fatal(err)
+	}
 	var networkInterfaces = make([]map[string]interface{}, 0)
 	for _, v := range interfaces {
 		networkInterfaces = append(networkInterfaces, flattenNetworkInterface(v))
@@ -92,14 +42,20 @@ func TestFlattenInterfaces(t *testing.T) {
 
 func TestFlattenPublishedServices(t *testing.T) {
 
+	response := string(readTestFile(t, "vm_interface_services_response.json"))
+
 	expected := make(map[string][]string)
 	expected["id"] = []string{"8080", "8081"}
 	expected["internal_port"] = []string{"8080", "8081"}
 	expected["external_ip"] = []string{"services-uswest.skytap.com", "services-useast.skytap.com"}
 	expected["external_port"] = []string{"26160", "17785"}
+	expected["name"] = []string{"one", "two"}
 
 	var services []skytap.PublishedService
-	json.Unmarshal([]byte(examplePublishedServiceListResponse), &services)
+	err := json.Unmarshal([]byte(response), &services)
+	if err != nil {
+		t.Fatal(err)
+	}
 	var publishedServices = make([]map[string]interface{}, 0)
 	for _, v := range services {
 		publishedServices = append(publishedServices, flattenPublishedService(v))

--- a/skytap/testdata/vm_interface_ports_response.json
+++ b/skytap/testdata/vm_interface_ports_response.json
@@ -1,0 +1,66 @@
+[
+    {
+        "id": "nic-20246343-38367563-0",
+        "ip": "192.168.0.1",
+        "hostname": "wins2016s",
+        "mac": "00:50:56:11:7D:D9",
+        "services_count": 0,
+        "services": [
+	    {
+            "id": "8080",
+            "internal_port": 8080,
+            "external_ip": "services-uswest.skytap.com",
+            "external_port": 26160
+        },
+        {
+            "id": "8081",
+            "internal_port": 8081,
+            "external_ip": "services-useast.skytap.com",
+            "external_port": 17785
+        }
+        ],
+        "public_ips_count": 0,
+        "public_ips": [],
+        "vm_id": "37527239",
+        "vm_name": "Windows Server 2016 Standard",
+        "status": "Running",
+        "network_id": "23917287",
+        "network_name": "tftest-network-1",
+        "network_url": "https://cloud.skytap.com/v2/configurations/40064014/networks/23917287",
+        "network_type": "automatic",
+        "network_subnet": "192.168.0.0/16",
+        "nic_type": "vmxnet3",
+        "secondary_ips": [],
+        "public_ip_attachments": []
+    },
+    {
+        "id": "nic-20246343-38367563-5",
+        "ip": "192.168.0.2",
+        "hostname": "wins2016s2",
+        "mac": "00:50:56:07:40:3F",
+        "services_count": 0,
+        "services": [
+	    {
+            "id": "8080",
+            "internal_port": 8080,
+            "external_ip": "services-uswest.skytap.com",
+            "external_port": 26160
+        },
+        {
+            "id": "8081",
+            "internal_port": 8081,
+            "external_ip": "services-useast.skytap.com",
+            "external_port": 17785
+    	}
+        ],
+        "public_ips_count": 0,
+        "public_ips": [],
+        "vm_id": "37527239",
+        "vm_name": "Windows Server 2016 Standard",
+        "status": "Running",
+        "network_id": "23917287",
+        "nic_type": "e1000",
+        "secondary_ips": [],
+        "public_ip_attachments": []
+    }
+]

--- a/skytap/testdata/vm_interface_response.json
+++ b/skytap/testdata/vm_interface_response.json
@@ -1,0 +1,40 @@
+[
+{
+"id": "nic-20246343-38367563-0",
+"ip": "192.168.0.1",
+"hostname": "wins2016s",
+"mac": "00:50:56:11:7D:D9",
+"services_count": 0,
+"services": [],
+"public_ips_count": 0,
+"public_ips": [],
+"vm_id": "37527239",
+"vm_name": "Windows Server 2016 Standard",
+"status": "Running",
+"network_id": "23917287",
+"network_name": "tftest-network-1",
+"network_url": "https://cloud.skytap.com/v2/configurations/40064014/networks/23917287",
+"network_type": "automatic",
+"network_subnet": "192.168.0.0/16",
+"nic_type": "vmxnet3",
+"secondary_ips": [],
+"public_ip_attachments": []
+},
+{
+"id": "nic-20246343-38367563-5",
+"ip": "192.168.0.2",
+"hostname": "wins2016s2",
+"mac": "00:50:56:07:40:3F",
+"services_count": 0,
+"services": [],
+"public_ips_count": 0,
+"public_ips": [],
+"vm_id": "37527239",
+"vm_name": "Windows Server 2016 Standard",
+"status": "Running",
+"network_id": "23917287",
+"nic_type": "e1000",
+"secondary_ips": [],
+"public_ip_attachments": []
+}
+]

--- a/skytap/testdata/vm_interface_services_response.json
+++ b/skytap/testdata/vm_interface_services_response.json
@@ -1,0 +1,16 @@
+[
+  {
+    "id": "8080",
+    "internal_port": 8080,
+    "external_ip": "services-uswest.skytap.com",
+    "external_port": 26160,
+    "name": "one"
+  },
+  {
+    "id": "8081",
+    "internal_port": 8081,
+    "external_ip": "services-useast.skytap.com",
+    "external_port": 17785,
+    "name": "two"
+  }
+]

--- a/skytap/utils/utils.go
+++ b/skytap/utils/utils.go
@@ -1,6 +1,8 @@
 package utils
 
-import "github.com/skytap/skytap-sdk-go/skytap"
+import (
+	"github.com/skytap/skytap-sdk-go/skytap"
+)
 
 // String returns a pointer to a string literal
 func String(s string) *string {

--- a/vendor/github.com/skytap/skytap-sdk-go/skytap/published_service.go
+++ b/vendor/github.com/skytap/skytap-sdk-go/skytap/published_service.go
@@ -73,6 +73,7 @@ type PublishedService struct {
 	InternalPort *int    `json:"internal_port"`
 	ExternalIP   *string `json:"external_ip"`
 	ExternalPort *int    `json:"external_port"`
+	Name         *string `json:"name,omitempty"`
 }
 
 // CreatePublishedServiceRequest describes the create the publishedService data

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -757,10 +757,12 @@
 			"revisionTime": "2018-09-10T08:07:58Z"
 		},
 		{
-			"checksumSHA1": "TnBhDsG4ik4XQ7wxYg9U4HZnryU=",
+			"checksumSHA1": "O5S83Z2heS0lA4uEbo0D8XqbNq8=",
 			"path": "github.com/skytap/skytap-sdk-go/skytap",
-			"revision": "127a79d5831c21bb1c89d4bffce9147510756a73",
-			"revisionTime": "2018-12-20T13:52:58Z"
+			"revision": "529cd6ba2e5c57e5b830690b73fce8074e3c43e1",
+			"revisionTime": "2018-12-21T10:23:05Z",
+			"version": "v2",
+			"versionExact": "v2"
 		},
 		{
 			"checksumSHA1": "c6pbpF7eowwO59phRTpF8cQ80Z0=",


### PR DESCRIPTION
To facilitate the provisioning of services it has been necessary to create a new map of published service external ports and external IPs. This map is keyed on the published service name. Please see issue #7 an for a usage example.

The network interface id has also been added to the schema.