### PR TITLE
Improve tests and documentation

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -15,7 +15,7 @@ test: fmtcheck
 		xargs -t -n4 go test $(TESTARGS) -timeout=30s -parallel=4
 
 testacc: fmtcheck
-	TF_ACC=1 go test $(TEST) -v $(TESTARGS) -timeout 120m
+	TF_ACC=1 go test $(TEST) -v $(TESTARGS) -timeout 180m
 
 vet:
 	@echo "go vet ."

--- a/skytap/data_source_skytap_template_test.go
+++ b/skytap/data_source_skytap_template_test.go
@@ -2,7 +2,6 @@ package skytap
 
 import (
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/resource"
@@ -11,16 +10,14 @@ import (
 func TestAccDataSourceSkytapTemplate_Basic(t *testing.T) {
 	//t.Parallel()
 
-	if setEnv(t, "SKYTAP_TEMPLATE_NAME", "Advanced Import Appliance on Ubuntu 18.04.1") {
-		defer unsetEnv("SKYTAP_TEMPLATE_NAME")
-	}
+	name := getEnv("SKYTAP_TEMPLATE_NAME", "Advanced Import Appliance on Ubuntu 18.04.1")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceSkytapTemplateConfig_basic(),
+				Config: testAccDataSourceSkytapTemplateConfig_basic(name),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.skytap_template.foo", "id"),
 				),
@@ -29,7 +26,7 @@ func TestAccDataSourceSkytapTemplate_Basic(t *testing.T) {
 	})
 }
 
-func testAccDataSourceSkytapTemplateConfig_basic() string {
+func testAccDataSourceSkytapTemplateConfig_basic(name string) string {
 	return fmt.Sprintf(`
 data "skytap_template" "foo" {
 	name = "%s"
@@ -37,35 +34,31 @@ data "skytap_template" "foo" {
 
 output "id" {
   value = "${data.skytap_template.foo.id}"
-}`, os.Getenv("SKYTAP_TEMPLATE_NAME"))
+}`, name)
 }
 
 func TestAccDataSourceSkytapTemplate_RegexMostRecent(t *testing.T) {
 	//t.Parallel()
 
-	if setEnv(t, "SKYTAP_TEMPLATE_NAME", "Advanced Import Appliance on Ubuntu 18.04.1") {
-		defer unsetEnv("SKYTAP_TEMPLATE_NAME")
-	}
-	if setEnv(t, "SKYTAP_TEMPLATE_NAME_PARTIAL", "Appliance on Ubuntu 18.04") {
-		defer unsetEnv("SKYTAP_TEMPLATE_NAME_PARTIAL")
-	}
+	name := getEnv("SKYTAP_TEMPLATE_NAME", "Advanced Import Appliance on Ubuntu 18.04.1")
+	namePartial := getEnv("SKYTAP_TEMPLATE_NAME_PARTIAL", "Appliance on Ubuntu 18.04")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceSkytapTemplateConfig_regexMostRecent(),
+				Config: testAccDataSourceSkytapTemplateConfig_regexMostRecent(namePartial),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.skytap_template.foo", "id"),
-					resource.TestCheckResourceAttr("data.skytap_template.foo", "name", os.Getenv("SKYTAP_TEMPLATE_NAME")),
+					resource.TestCheckResourceAttr("data.skytap_template.foo", "name", name),
 				),
 			},
 		},
 	})
 }
 
-func testAccDataSourceSkytapTemplateConfig_regexMostRecent() string {
+func testAccDataSourceSkytapTemplateConfig_regexMostRecent(partial string) string {
 	return fmt.Sprintf(`
 data "skytap_template" "foo" {
 	name = "%s"
@@ -74,5 +67,5 @@ data "skytap_template" "foo" {
 
 output "id" {
   value = "${data.skytap_template.foo.id}"
-}`, os.Getenv("SKYTAP_TEMPLATE_NAME_PARTIAL"))
+}`, partial)
 }

--- a/skytap/data_source_skytap_template_test.go
+++ b/skytap/data_source_skytap_template_test.go
@@ -2,7 +2,6 @@ package skytap
 
 import (
 	"fmt"
-	"log"
 	"os"
 	"testing"
 
@@ -12,9 +11,8 @@ import (
 func TestAccDataSourceSkytapTemplate_Basic(t *testing.T) {
 	//t.Parallel()
 
-	if os.Getenv("SKYTAP_TEMPLATE_NAME") == "" {
-		log.Printf("[WARN] SKYTAP_TEMPLATE_NAME required to run skytap_template_datasource acceptance tests. Setting: SKYTAP_TEMPLATE_NAME=Advanced Import Appliance on Ubuntu 18.04.1")
-		os.Setenv("SKYTAP_TEMPLATE_NAME", "Advanced Import Appliance on Ubuntu 18.04.1")
+	if setEnv(t, "SKYTAP_TEMPLATE_NAME", "Advanced Import Appliance on Ubuntu 18.04.1") {
+		defer unsetEnv("SKYTAP_TEMPLATE_NAME")
 	}
 
 	resource.Test(t, resource.TestCase{
@@ -45,13 +43,11 @@ output "id" {
 func TestAccDataSourceSkytapTemplate_RegexMostRecent(t *testing.T) {
 	//t.Parallel()
 
-	if os.Getenv("SKYTAP_TEMPLATE_NAME") == "" {
-		log.Printf("[WARN] SKYTAP_TEMPLATE_NAME required to run skytap_template_datasource acceptance tests. Setting: SKYTAP_TEMPLATE_NAME=Advanced Import Appliance on Ubuntu 18.04.1")
-		os.Setenv("SKYTAP_TEMPLATE_NAME", "Advanced Import Appliance on Ubuntu 18.04.1")
+	if setEnv(t, "SKYTAP_TEMPLATE_NAME", "Advanced Import Appliance on Ubuntu 18.04.1") {
+		defer unsetEnv("SKYTAP_TEMPLATE_NAME")
 	}
-	if os.Getenv("SKYTAP_TEMPLATE_NAME_PARTIAL") == "" {
-		log.Printf("[WARN] SKYTAP_TEMPLATE_NAME_PARTIAL required to run skytap_template_datasource acceptance tests. Setting: SKYTAP_TEMPLATE_NAME_PARTIAL=18.04")
-		os.Setenv("SKYTAP_TEMPLATE_NAME_PARTIAL", "18.04")
+	if setEnv(t, "SKYTAP_TEMPLATE_NAME_PARTIAL", "Appliance on Ubuntu 18.04") {
+		defer unsetEnv("SKYTAP_TEMPLATE_NAME_PARTIAL")
 	}
 
 	resource.Test(t, resource.TestCase{

--- a/skytap/data_source_skytap_template_test.go
+++ b/skytap/data_source_skytap_template_test.go
@@ -5,12 +5,13 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/terraform-providers/terraform-provider-skytap/skytap/utils"
 )
 
 func TestAccDataSourceSkytapTemplate_Basic(t *testing.T) {
 	//t.Parallel()
 
-	name := getEnv("SKYTAP_TEMPLATE_NAME", "Advanced Import Appliance on Ubuntu 18.04.1")
+	name := utils.GetEnv("SKYTAP_TEMPLATE_NAME", "Advanced Import Appliance on Ubuntu 18.04.1")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
@@ -40,8 +41,8 @@ output "id" {
 func TestAccDataSourceSkytapTemplate_RegexMostRecent(t *testing.T) {
 	//t.Parallel()
 
-	name := getEnv("SKYTAP_TEMPLATE_NAME", "Advanced Import Appliance on Ubuntu 18.04.1")
-	namePartial := getEnv("SKYTAP_TEMPLATE_NAME_PARTIAL", "Appliance on Ubuntu 18.04")
+	name := utils.GetEnv("SKYTAP_TEMPLATE_NAME", "Advanced Import Appliance on Ubuntu 18.04.1")
+	namePartial := utils.GetEnv("SKYTAP_TEMPLATE_NAME_PARTIAL", "Appliance on Ubuntu 18.04")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },

--- a/skytap/resource_skytap_environment_test.go
+++ b/skytap/resource_skytap_environment_test.go
@@ -49,7 +49,7 @@ func testSweepSkytapEnvironment(region string) error {
 func TestAccSkytapEnvironment_Basic(t *testing.T) {
 	//t.Parallel()
 
-	templateID := getEnv("SKYTAP_TEMPLATE_ID", "1473407")
+	templateID := utils.GetEnv("SKYTAP_TEMPLATE_ID", "1473407")
 	uniqueSuffix := acctest.RandInt()
 	var environment skytap.Environment
 
@@ -80,8 +80,8 @@ func TestAccSkytapEnvironment_Basic(t *testing.T) {
 func TestAccSkytapEnvironment_UpdateTemplate(t *testing.T) {
 	//t.Parallel()
 
-	templateID := getEnv("SKYTAP_TEMPLATE_ID", "1473407")
-	template2ID := getEnv("SKYTAP_TEMPLATE_ID2", "1473347")
+	templateID := utils.GetEnv("SKYTAP_TEMPLATE_ID", "1473407")
+	template2ID := utils.GetEnv("SKYTAP_TEMPLATE_ID2", "1473347")
 	rInt := acctest.RandInt()
 	var environment skytap.Environment
 

--- a/skytap/resource_skytap_environment_test.go
+++ b/skytap/resource_skytap_environment_test.go
@@ -50,9 +50,8 @@ func testSweepSkytapEnvironment(region string) error {
 func TestAccSkytapEnvironment_Basic(t *testing.T) {
 	//t.Parallel()
 
-	if os.Getenv("SKYTAP_TEMPLATE_ID") == "" {
-		log.Printf("[WARN] SKYTAP_TEMPLATE_ID required to run skytap_environment_resource acceptance tests. Setting: SKYTAP_TEMPLATE_ID=1473407")
-		os.Setenv("SKYTAP_TEMPLATE_ID", "1473407")
+	if setEnv(t, "SKYTAP_TEMPLATE_ID", "1473407") {
+		defer unsetEnv("SKYTAP_TEMPLATE_ID")
 	}
 
 	uniqueSuffix := acctest.RandInt()
@@ -85,13 +84,11 @@ func TestAccSkytapEnvironment_Basic(t *testing.T) {
 func TestAccSkytapEnvironment_UpdateTemplate(t *testing.T) {
 	//t.Parallel()
 
-	if os.Getenv("SKYTAP_TEMPLATE_ID") == "" {
-		log.Printf("[WARN] SKYTAP_TEMPLATE_ID required to run skytap_environment_resource acceptance tests. Setting: SKYTAP_TEMPLATE_ID=1473407")
-		os.Setenv("SKYTAP_TEMPLATE_ID", "1473407")
+	if setEnv(t, "SKYTAP_TEMPLATE_ID", "1473407") {
+		defer unsetEnv("SKYTAP_TEMPLATE_ID")
 	}
-	if os.Getenv("SKYTAP_TEMPLATE_ID2") == "" {
-		log.Printf("[WARN] SKYTAP_TEMPLATE_ID2 required to run skytap_environment_resource acceptance tests. Setting: SKYTAP_TEMPLATE_ID2=1473347")
-		os.Setenv("SKYTAP_TEMPLATE_ID2", "1473347")
+	if setEnv(t, "SKYTAP_TEMPLATE_ID2", "1473347") {
+		defer unsetEnv("SKYTAP_TEMPLATE_ID2")
 	}
 
 	rInt := acctest.RandInt()

--- a/skytap/resource_skytap_environment_test.go
+++ b/skytap/resource_skytap_environment_test.go
@@ -3,7 +3,6 @@ package skytap
 import (
 	"fmt"
 	"log"
-	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/acctest"
@@ -50,10 +49,7 @@ func testSweepSkytapEnvironment(region string) error {
 func TestAccSkytapEnvironment_Basic(t *testing.T) {
 	//t.Parallel()
 
-	if setEnv(t, "SKYTAP_TEMPLATE_ID", "1473407") {
-		defer unsetEnv("SKYTAP_TEMPLATE_ID")
-	}
-
+	templateID := getEnv("SKYTAP_TEMPLATE_ID", "1473407")
 	uniqueSuffix := acctest.RandInt()
 	var environment skytap.Environment
 
@@ -63,7 +59,7 @@ func TestAccSkytapEnvironment_Basic(t *testing.T) {
 		CheckDestroy: testAccCheckSkytapEnvironmentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSkytapEnvironmentConfig_basic(uniqueSuffix, os.Getenv("SKYTAP_TEMPLATE_ID")),
+				Config: testAccSkytapEnvironmentConfig_basic(uniqueSuffix, templateID),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSkytapEnvironmentExists("skytap_environment.foo", &environment),
 					resource.TestCheckResourceAttr("skytap_environment.foo", "name", fmt.Sprintf("tftest-environment-%d", uniqueSuffix)),
@@ -84,13 +80,8 @@ func TestAccSkytapEnvironment_Basic(t *testing.T) {
 func TestAccSkytapEnvironment_UpdateTemplate(t *testing.T) {
 	//t.Parallel()
 
-	if setEnv(t, "SKYTAP_TEMPLATE_ID", "1473407") {
-		defer unsetEnv("SKYTAP_TEMPLATE_ID")
-	}
-	if setEnv(t, "SKYTAP_TEMPLATE_ID2", "1473347") {
-		defer unsetEnv("SKYTAP_TEMPLATE_ID2")
-	}
-
+	templateID := getEnv("SKYTAP_TEMPLATE_ID", "1473407")
+	template2ID := getEnv("SKYTAP_TEMPLATE_ID2", "1473347")
 	rInt := acctest.RandInt()
 	var environment skytap.Environment
 
@@ -100,13 +91,13 @@ func TestAccSkytapEnvironment_UpdateTemplate(t *testing.T) {
 		CheckDestroy: testAccCheckSkytapEnvironmentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSkytapEnvironmentConfig_basic(rInt, os.Getenv("SKYTAP_TEMPLATE_ID")),
+				Config: testAccSkytapEnvironmentConfig_basic(rInt, templateID),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSkytapEnvironmentExists("skytap_environment.foo", &environment),
 				),
 			},
 			{
-				Config: testAccSkytapEnvironmentConfig_basic(rInt, os.Getenv("SKYTAP_TEMPLATE_ID2")),
+				Config: testAccSkytapEnvironmentConfig_basic(rInt, template2ID),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSkytapEnvironmentAfterTemplateChanged("skytap_environment.foo", &environment),
 				),

--- a/skytap/resource_skytap_network_test.go
+++ b/skytap/resource_skytap_network_test.go
@@ -54,9 +54,8 @@ func testSweepSkytapNetwork(region string) error {
 func TestAccSkytapNetwork_Basic(t *testing.T) {
 	//t.Parallel()
 
-	if os.Getenv("SKYTAP_TEMPLATE_ID") == "" {
-		log.Printf("[WARN] SKYTAP_TEMPLATE_ID required to run skytap_network_resource acceptance tests. Setting: SKYTAP_TEMPLATE_ID=1473407")
-		os.Setenv("SKYTAP_TEMPLATE_ID", "1473407")
+	if setEnv(t, "SKYTAP_TEMPLATE_ID", "1473407") {
+		defer unsetEnv("SKYTAP_TEMPLATE_ID")
 	}
 
 	uniqueSuffixEnv := acctest.RandInt()
@@ -87,9 +86,8 @@ func TestAccSkytapNetwork_Basic(t *testing.T) {
 func TestAccSkytapNetwork_Update(t *testing.T) {
 	//t.Parallel()
 
-	if os.Getenv("SKYTAP_TEMPLATE_ID") == "" {
-		log.Printf("[WARN] SKYTAP_TEMPLATE_ID required to run skytap_network_resource acceptance tests. Setting: SKYTAP_TEMPLATE_ID=1473407")
-		os.Setenv("SKYTAP_TEMPLATE_ID", "1473407")
+	if setEnv(t, "SKYTAP_TEMPLATE_ID", "1473407") {
+		defer unsetEnv("SKYTAP_TEMPLATE_ID")
 	}
 
 	uniqueSuffixEnv := acctest.RandInt()

--- a/skytap/resource_skytap_network_test.go
+++ b/skytap/resource_skytap_network_test.go
@@ -53,7 +53,7 @@ func testSweepSkytapNetwork(region string) error {
 func TestAccSkytapNetwork_Basic(t *testing.T) {
 	//t.Parallel()
 
-	templateID := getEnv("SKYTAP_TEMPLATE_ID", "1473407")
+	templateID := utils.GetEnv("SKYTAP_TEMPLATE_ID", "1473407")
 	uniqueSuffixEnv := acctest.RandInt()
 	uniqueSuffixNet := acctest.RandInt()
 	var network skytap.Network
@@ -82,7 +82,7 @@ func TestAccSkytapNetwork_Basic(t *testing.T) {
 func TestAccSkytapNetwork_Update(t *testing.T) {
 	//t.Parallel()
 
-	templateID := getEnv("SKYTAP_TEMPLATE_ID", "1473407")
+	templateID := utils.GetEnv("SKYTAP_TEMPLATE_ID", "1473407")
 	uniqueSuffixEnv := acctest.RandInt()
 	uniqueSuffixInitial := acctest.RandInt()
 	uniqueSuffixUpdate := acctest.RandInt()

--- a/skytap/resource_skytap_network_test.go
+++ b/skytap/resource_skytap_network_test.go
@@ -3,7 +3,6 @@ package skytap
 import (
 	"fmt"
 	"log"
-	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/acctest"
@@ -54,10 +53,7 @@ func testSweepSkytapNetwork(region string) error {
 func TestAccSkytapNetwork_Basic(t *testing.T) {
 	//t.Parallel()
 
-	if setEnv(t, "SKYTAP_TEMPLATE_ID", "1473407") {
-		defer unsetEnv("SKYTAP_TEMPLATE_ID")
-	}
-
+	templateID := getEnv("SKYTAP_TEMPLATE_ID", "1473407")
 	uniqueSuffixEnv := acctest.RandInt()
 	uniqueSuffixNet := acctest.RandInt()
 	var network skytap.Network
@@ -68,7 +64,7 @@ func TestAccSkytapNetwork_Basic(t *testing.T) {
 		CheckDestroy: testAccCheckSkytapEnvironmentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSkytapNetworkConfig_basic(os.Getenv("SKYTAP_TEMPLATE_ID"), uniqueSuffixEnv, uniqueSuffixNet, "skytap.io", "192.168.1.0/24", "", true),
+				Config: testAccSkytapNetworkConfig_basic(templateID, uniqueSuffixEnv, uniqueSuffixNet, "skytap.io", "192.168.1.0/24", "", true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSkytapNetworkExists("skytap_environment.foo", "skytap_network.bar", &network),
 					resource.TestCheckResourceAttrSet("skytap_network.bar", "environment_id"),
@@ -86,10 +82,7 @@ func TestAccSkytapNetwork_Basic(t *testing.T) {
 func TestAccSkytapNetwork_Update(t *testing.T) {
 	//t.Parallel()
 
-	if setEnv(t, "SKYTAP_TEMPLATE_ID", "1473407") {
-		defer unsetEnv("SKYTAP_TEMPLATE_ID")
-	}
-
+	templateID := getEnv("SKYTAP_TEMPLATE_ID", "1473407")
 	uniqueSuffixEnv := acctest.RandInt()
 	uniqueSuffixInitial := acctest.RandInt()
 	uniqueSuffixUpdate := acctest.RandInt()
@@ -101,7 +94,7 @@ func TestAccSkytapNetwork_Update(t *testing.T) {
 		CheckDestroy: testAccCheckSkytapEnvironmentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSkytapNetworkConfig_basic(os.Getenv("SKYTAP_TEMPLATE_ID"), uniqueSuffixEnv, uniqueSuffixInitial, "skytap.io", "192.168.1.0/24", "gateway = \"192.168.1.1\"", true),
+				Config: testAccSkytapNetworkConfig_basic(templateID, uniqueSuffixEnv, uniqueSuffixInitial, "skytap.io", "192.168.1.0/24", "gateway = \"192.168.1.1\"", true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSkytapNetworkExists("skytap_environment.foo", "skytap_network.bar", &network),
 					resource.TestCheckResourceAttr("skytap_network.bar", "name", fmt.Sprintf("tftest-network-%d", uniqueSuffixInitial)),
@@ -112,7 +105,7 @@ func TestAccSkytapNetwork_Update(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccSkytapNetworkConfig_basic(os.Getenv("SKYTAP_TEMPLATE_ID"), uniqueSuffixEnv, uniqueSuffixUpdate, "skytap.com", "192.168.2.0/24", "gateway = \"192.168.2.1\"", false),
+				Config: testAccSkytapNetworkConfig_basic(templateID, uniqueSuffixEnv, uniqueSuffixUpdate, "skytap.com", "192.168.2.0/24", "gateway = \"192.168.2.1\"", false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSkytapNetworkExists("skytap_environment.foo", "skytap_network.bar", &network),
 					resource.TestCheckResourceAttr("skytap_network.bar", "name", fmt.Sprintf("tftest-network-%d", uniqueSuffixUpdate)),

--- a/skytap/resource_skytap_vm.go
+++ b/skytap/resource_skytap_vm.go
@@ -94,14 +94,14 @@ func resourceSkytapVM() *schema.Resource {
 							Type:     schema.TypeString,
 							Required: true,
 						},
-						"id": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
 						"size": {
 							Type:         schema.TypeInt,
 							Required:     true,
 							ValidateFunc: validation.IntBetween(2048, 2096128),
+						},
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
 						},
 						"type": {
 							Type:     schema.TypeString,
@@ -139,10 +139,6 @@ func resourceSkytapVM() *schema.Resource {
 							ForceNew:     true,
 							ValidateFunc: validation.NoZeroValues,
 						},
-						"id": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
 						"ip": {
 							Type:         schema.TypeString,
 							Required:     true,
@@ -154,6 +150,10 @@ func resourceSkytapVM() *schema.Resource {
 							Required:     true,
 							ForceNew:     true,
 							ValidateFunc: validation.NoZeroValues,
+						},
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
 						},
 
 						"published_service": {
@@ -175,11 +175,11 @@ func resourceSkytapVM() *schema.Resource {
 										ForceNew:     true,
 										ValidateFunc: validation.NoZeroValues,
 									},
-									"external_ip": {
+									"id": {
 										Type:     schema.TypeString,
 										Computed: true,
 									},
-									"id": {
+									"external_ip": {
 										Type:     schema.TypeString,
 										Computed: true,
 									},

--- a/skytap/resource_skytap_vm_hardware_test.go
+++ b/skytap/resource_skytap_vm_hardware_test.go
@@ -64,6 +64,7 @@ func TestAccSkytapVMCPURam_Create(t *testing.T) {
 	})
 }
 
+// To ensure the presence of a disk works unchanged
 func TestAccSkytapVMCPU_DiskIntact(t *testing.T) {
 	//t.Parallel()
 
@@ -87,6 +88,7 @@ func TestAccSkytapVMCPU_DiskIntact(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSkytapVMExists("skytap_environment.foo", "skytap_vm.bar", &vm),
 					resource.TestCheckResourceAttr("skytap_vm.bar", "cpus", "8"),
+					testAccCheckSkytapVMDiskResource(t, "skytap_vm.bar", "1", []string{"smaller"}),
 					testAccCheckSkytapVMCPU(t, &vm, 8),
 					testAccCheckSkytapVMDisks(t, &vm, []int{2048}),
 				),
@@ -101,58 +103,11 @@ func TestAccSkytapVMCPU_DiskIntact(t *testing.T) {
 									}`),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSkytapVMExists("skytap_environment.foo", "skytap_vm.bar", &vmUpdated),
+					resource.TestCheckResourceAttr("skytap_vm.bar", "cpus", "4"),
 					testAccCheckSkytapVMDiskResource(t, "skytap_vm.bar", "1", []string{"disk1"}),
 					testAccCheckSkytapVMUpdated(t, &vm, &vmUpdated),
 					testAccCheckSkytapVMCPU(t, &vmUpdated, 4),
 					testAccCheckSkytapVMDisks(t, &vmUpdated, []int{2048}),
-				),
-			},
-		},
-	})
-}
-
-// To ensure the presence of a disk works unchanged
-func TestAccSkytapVMCPU_WithDisk(t *testing.T) {
-	//t.Parallel()
-
-	templateID, vmID, newEnvTemplateID := setupEnvironment("1473407", "37865463")
-	uniqueSuffixEnv := acctest.RandInt()
-	var vm skytap.VM
-	var vmUpdated skytap.VM
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckSkytapEnvironmentDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccSkytapVMConfig_basic(newEnvTemplateID, uniqueSuffixEnv, "", templateID, vmID, "", "",
-					`"cpus" = 8
-									"disk" = {
-										"size" = 2048
-										"name" = "smaller"
-									}`),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckSkytapVMExists("skytap_environment.foo", "skytap_vm.bar", &vm),
-					resource.TestCheckResourceAttr("skytap_vm.bar", "cpus", "8"),
-					testAccCheckSkytapVMCPU(t, &vm, 8),
-					testAccCheckSkytapVMDiskResource(t, "skytap_vm.bar", "1", []string{"smaller"}),
-				),
-			},
-			{
-				PreConfig: pause(),
-				Config: testAccSkytapVMConfig_basic(newEnvTemplateID, uniqueSuffixEnv, "", templateID, vmID, "", "",
-					`"cpus" = 4
-									"disk" = {
-										"size" = 2048
-										"name" = "smaller"
-									}`),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckSkytapVMExists("skytap_environment.foo", "skytap_vm.bar", &vmUpdated),
-					resource.TestCheckResourceAttr("skytap_vm.bar", "cpus", "4"),
-					testAccCheckSkytapVMDiskResource(t, "skytap_vm.bar", "1", []string{"smaller"}),
-					testAccCheckSkytapVMUpdated(t, &vm, &vmUpdated),
-					testAccCheckSkytapVMCPU(t, &vmUpdated, 4),
 				),
 			},
 		},

--- a/skytap/resource_skytap_vm_hardware_test.go
+++ b/skytap/resource_skytap_vm_hardware_test.go
@@ -17,7 +17,7 @@ import (
 func TestAccSkytapVMCPURam_Create(t *testing.T) {
 	//t.Parallel()
 
-	templateID, vmID, newEnvTemplateID := setupEnvironment("1473407", "37865463")
+	templateID, vmID, newEnvTemplateID := setupEnvironment()
 	uniqueSuffixEnv := acctest.RandInt()
 	var vm skytap.VM
 	var vmUpdated skytap.VM
@@ -68,7 +68,7 @@ func TestAccSkytapVMCPURam_Create(t *testing.T) {
 func TestAccSkytapVMCPU_DiskIntact(t *testing.T) {
 	//t.Parallel()
 
-	templateID, vmID, newEnvTemplateID := setupEnvironment("1473407", "37865463")
+	templateID, vmID, newEnvTemplateID := setupEnvironment()
 	uniqueSuffixEnv := acctest.RandInt()
 	var vm skytap.VM
 	var vmUpdated skytap.VM
@@ -117,7 +117,7 @@ func TestAccSkytapVMCPU_DiskIntact(t *testing.T) {
 func TestAccSkytapVMCPURAM_UpdateNPECheck(t *testing.T) {
 	//t.Parallel()
 
-	templateID, vmID, newEnvTemplateID := setupEnvironment("1473407", "37865463")
+	templateID, vmID, newEnvTemplateID := setupEnvironment()
 	uniqueSuffixEnv := acctest.RandInt()
 	var vm skytap.VM
 	var vmUpdated skytap.VM
@@ -152,7 +152,7 @@ func TestAccSkytapVMCPURAM_UpdateNPECheck(t *testing.T) {
 func TestAccSkytapVMCPURAM_Invalid(t *testing.T) {
 	//t.Parallel()
 
-	templateID, vmID, newEnvTemplateID := setupEnvironment("1473407", "37865463")
+	templateID, vmID, newEnvTemplateID := setupEnvironment()
 	uniqueSuffixEnv := acctest.RandInt()
 
 	resource.Test(t, resource.TestCase{
@@ -173,7 +173,7 @@ func TestAccSkytapVMCPURAM_Invalid(t *testing.T) {
 func TestAccSkytapVMCPU_OutOfRange(t *testing.T) {
 	//t.Parallel()
 
-	templateID, vmID, newEnvTemplateID := setupEnvironmentWithKeys("SKYTAP_TEMPLATE_OUTOFRANGE_ID", "136409", "SKYTAP_VM_OUTOFRANGE_ID", "849656")
+	templateID, vmID, newEnvTemplateID := setupNonDefaultEnvironment("SKYTAP_TEMPLATE_OUTOFRANGE_ID", "136409", "SKYTAP_VM_OUTOFRANGE_ID", "849656")
 	uniqueSuffixEnv := acctest.RandInt()
 
 	resource.Test(t, resource.TestCase{
@@ -194,7 +194,7 @@ func TestAccSkytapVMCPU_OutOfRange(t *testing.T) {
 func TestAccSkytapVMCPU_OutOfRangeAfterUpdate(t *testing.T) {
 	//t.Parallel()
 
-	templateID, vmID, newEnvTemplateID := setupEnvironmentWithKeys("SKYTAP_TEMPLATE_OUTOFRANGE_ID", "136409", "SKYTAP_VM_OUTOFRANGE_ID", "849656")
+	templateID, vmID, newEnvTemplateID := setupNonDefaultEnvironment("SKYTAP_TEMPLATE_OUTOFRANGE_ID", "136409", "SKYTAP_VM_OUTOFRANGE_ID", "849656")
 	uniqueSuffixEnv := acctest.RandInt()
 
 	resource.Test(t, resource.TestCase{
@@ -219,7 +219,7 @@ func TestAccSkytapVMCPU_OutOfRangeAfterUpdate(t *testing.T) {
 func TestAccSkytapVMDisks_Create(t *testing.T) {
 	//t.Parallel()
 
-	templateID, vmID, newEnvTemplateID := setupEnvironment("1473407", "37865463")
+	templateID, vmID, newEnvTemplateID := setupEnvironment()
 	uniqueSuffixEnv := acctest.RandInt()
 	var vm skytap.VM
 	var vmUpdated skytap.VM
@@ -275,7 +275,7 @@ func TestAccSkytapVMDisks_Create(t *testing.T) {
 func TestAccSkytapVMDisks_UpdateNPECheck(t *testing.T) {
 	//t.Parallel()
 
-	templateID, vmID, newEnvTemplateID := setupEnvironment("1473407", "37865463")
+	templateID, vmID, newEnvTemplateID := setupEnvironment()
 	uniqueSuffixEnv := acctest.RandInt()
 	var vm skytap.VM
 	var vmUpdated skytap.VM
@@ -313,7 +313,7 @@ func TestAccSkytapVMDisks_UpdateNPECheck(t *testing.T) {
 func TestAccSkytapVMDisks_Resize(t *testing.T) {
 	//t.Parallel()
 
-	templateID, vmID, newEnvTemplateID := setupEnvironment("1473407", "37865463")
+	templateID, vmID, newEnvTemplateID := setupEnvironment()
 	uniqueSuffixEnv := acctest.RandInt()
 	var vm skytap.VM
 	var vmUpdated skytap.VM
@@ -364,7 +364,7 @@ func TestAccSkytapVMDisks_Resize(t *testing.T) {
 func TestAccSkytapVMDisk_Invalid(t *testing.T) {
 	//t.Parallel()
 
-	templateID, vmID, newEnvTemplateID := setupEnvironment("1473407", "37865463")
+	templateID, vmID, newEnvTemplateID := setupEnvironment()
 	uniqueSuffixEnv := acctest.RandInt()
 
 	resource.Test(t, resource.TestCase{
@@ -395,7 +395,7 @@ func TestAccSkytapVMDisk_Invalid(t *testing.T) {
 func TestAccSkytapVMDisk_OS(t *testing.T) {
 	//t.Parallel()
 
-	templateID, vmID, newEnvTemplateID := setupEnvironment("1473407", "37865463")
+	templateID, vmID, newEnvTemplateID := setupEnvironment()
 	uniqueSuffixEnv := acctest.RandInt()
 	var vm skytap.VM
 	var vmUpdated skytap.VM
@@ -439,7 +439,7 @@ func TestAccSkytapVMDisk_OS(t *testing.T) {
 func TestAccSkytapVMDisk_OSChangeAfter(t *testing.T) {
 	//t.Parallel()
 
-	templateID, vmID, newEnvTemplateID := setupEnvironment("1473407", "37865463")
+	templateID, vmID, newEnvTemplateID := setupEnvironment()
 	uniqueSuffixEnv := acctest.RandInt()
 	var vm skytap.VM
 	var vmUpdated skytap.VM

--- a/skytap/resource_skytap_vm_hardware_test.go
+++ b/skytap/resource_skytap_vm_hardware_test.go
@@ -2,7 +2,6 @@ package skytap
 
 import (
 	"fmt"
-	"os"
 	"regexp"
 	"sort"
 	"testing"
@@ -18,13 +17,7 @@ import (
 func TestAccSkytapVMCPURam_Create(t *testing.T) {
 	//t.Parallel()
 
-	templateSet, vmSet, newEnvTemplateID := setupEnvironment(t, "136409", "849656")
-	if templateSet {
-		defer unsetEnv("SKYTAP_TEMPLATE_ID")
-	}
-	if vmSet {
-		defer unsetEnv("SKYTAP_VM_ID")
-	}
+	templateID, vmID, newEnvTemplateID := setupEnvironment("1473407", "37865463")
 	uniqueSuffixEnv := acctest.RandInt()
 	var vm skytap.VM
 	var vmUpdated skytap.VM
@@ -35,7 +28,7 @@ func TestAccSkytapVMCPURam_Create(t *testing.T) {
 		CheckDestroy: testAccCheckSkytapEnvironmentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSkytapVMConfig_basic(newEnvTemplateID, uniqueSuffixEnv, "", os.Getenv("SKYTAP_TEMPLATE_ID"), os.Getenv("SKYTAP_VM_ID"), "", "",
+				Config: testAccSkytapVMConfig_basic(newEnvTemplateID, uniqueSuffixEnv, "", templateID, vmID, "", "",
 					`"cpus" = 8`),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSkytapVMExists("skytap_environment.foo", "skytap_vm.bar", &vm),
@@ -45,7 +38,7 @@ func TestAccSkytapVMCPURam_Create(t *testing.T) {
 			},
 			{
 				PreConfig: pause(),
-				Config: testAccSkytapVMConfig_basic(newEnvTemplateID, uniqueSuffixEnv, "", os.Getenv("SKYTAP_TEMPLATE_ID"), os.Getenv("SKYTAP_VM_ID"), "", "",
+				Config: testAccSkytapVMConfig_basic(newEnvTemplateID, uniqueSuffixEnv, "", templateID, vmID, "", "",
 					`"ram" = 8192`),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSkytapVMExists("skytap_environment.foo", "skytap_vm.bar", &vmUpdated),
@@ -56,7 +49,7 @@ func TestAccSkytapVMCPURam_Create(t *testing.T) {
 			},
 			{
 				PreConfig: pause(),
-				Config: testAccSkytapVMConfig_basic(newEnvTemplateID, uniqueSuffixEnv, "", os.Getenv("SKYTAP_TEMPLATE_ID"), os.Getenv("SKYTAP_VM_ID"), "", "",
+				Config: testAccSkytapVMConfig_basic(newEnvTemplateID, uniqueSuffixEnv, "", templateID, vmID, "", "",
 					`"cpus" = 4
 									"ram" = 4096`),
 				Check: resource.ComposeTestCheckFunc(
@@ -78,13 +71,7 @@ func pause() func() {
 func TestAccSkytapVMCPU_DiskIntact(t *testing.T) {
 	//t.Parallel()
 
-	templateSet, vmSet, newEnvTemplateID := setupEnvironment(t, "136409", "849656")
-	if templateSet {
-		defer unsetEnv("SKYTAP_TEMPLATE_ID")
-	}
-	if vmSet {
-		defer unsetEnv("SKYTAP_VM_ID")
-	}
+	templateID, vmID, newEnvTemplateID := setupEnvironment("1473407", "37865463")
 	uniqueSuffixEnv := acctest.RandInt()
 	var vm skytap.VM
 	var vmUpdated skytap.VM
@@ -95,7 +82,7 @@ func TestAccSkytapVMCPU_DiskIntact(t *testing.T) {
 		CheckDestroy: testAccCheckSkytapEnvironmentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSkytapVMConfig_basic(newEnvTemplateID, uniqueSuffixEnv, "", os.Getenv("SKYTAP_TEMPLATE_ID"), os.Getenv("SKYTAP_VM_ID"), "", "",
+				Config: testAccSkytapVMConfig_basic(newEnvTemplateID, uniqueSuffixEnv, "", templateID, vmID, "", "",
 					`"cpus" = 8
 									"disk" = {
 										"size" = 2048
@@ -110,7 +97,7 @@ func TestAccSkytapVMCPU_DiskIntact(t *testing.T) {
 			},
 			{
 				PreConfig: pause(),
-				Config: testAccSkytapVMConfig_basic(newEnvTemplateID, uniqueSuffixEnv, "", os.Getenv("SKYTAP_TEMPLATE_ID"), os.Getenv("SKYTAP_VM_ID"), "", "",
+				Config: testAccSkytapVMConfig_basic(newEnvTemplateID, uniqueSuffixEnv, "", templateID, vmID, "", "",
 					`"cpus" = 4
 									"disk" = {
 										"size" = 2048
@@ -132,13 +119,7 @@ func TestAccSkytapVMCPU_DiskIntact(t *testing.T) {
 func TestAccSkytapVMCPU_WithDisk(t *testing.T) {
 	//t.Parallel()
 
-	templateSet, vmSet, newEnvTemplateID := setupEnvironment(t, "136409", "849656")
-	if templateSet {
-		defer unsetEnv("SKYTAP_TEMPLATE_ID")
-	}
-	if vmSet {
-		defer unsetEnv("SKYTAP_VM_ID")
-	}
+	templateID, vmID, newEnvTemplateID := setupEnvironment("1473407", "37865463")
 	uniqueSuffixEnv := acctest.RandInt()
 	var vm skytap.VM
 	var vmUpdated skytap.VM
@@ -149,7 +130,7 @@ func TestAccSkytapVMCPU_WithDisk(t *testing.T) {
 		CheckDestroy: testAccCheckSkytapEnvironmentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSkytapVMConfig_basic(newEnvTemplateID, uniqueSuffixEnv, "", os.Getenv("SKYTAP_TEMPLATE_ID"), os.Getenv("SKYTAP_VM_ID"), "", "",
+				Config: testAccSkytapVMConfig_basic(newEnvTemplateID, uniqueSuffixEnv, "", templateID, vmID, "", "",
 					`"cpus" = 8
 									"disk" = {
 										"size" = 2048
@@ -164,7 +145,7 @@ func TestAccSkytapVMCPU_WithDisk(t *testing.T) {
 			},
 			{
 				PreConfig: pause(),
-				Config: testAccSkytapVMConfig_basic(newEnvTemplateID, uniqueSuffixEnv, "", os.Getenv("SKYTAP_TEMPLATE_ID"), os.Getenv("SKYTAP_VM_ID"), "", "",
+				Config: testAccSkytapVMConfig_basic(newEnvTemplateID, uniqueSuffixEnv, "", templateID, vmID, "", "",
 					`"cpus" = 4
 									"disk" = {
 										"size" = 2048
@@ -173,9 +154,9 @@ func TestAccSkytapVMCPU_WithDisk(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSkytapVMExists("skytap_environment.foo", "skytap_vm.bar", &vmUpdated),
 					resource.TestCheckResourceAttr("skytap_vm.bar", "cpus", "4"),
+					testAccCheckSkytapVMDiskResource(t, "skytap_vm.bar", "1", []string{"smaller"}),
 					testAccCheckSkytapVMUpdated(t, &vm, &vmUpdated),
 					testAccCheckSkytapVMCPU(t, &vmUpdated, 4),
-					testAccCheckSkytapVMDiskResource(t, "skytap_vm.bar", "1", []string{"smaller"}),
 				),
 			},
 		},
@@ -185,13 +166,7 @@ func TestAccSkytapVMCPU_WithDisk(t *testing.T) {
 func TestAccSkytapVMCPURAM_UpdateNPECheck(t *testing.T) {
 	//t.Parallel()
 
-	templateSet, vmSet, newEnvTemplateID := setupEnvironment(t, "136409", "849656")
-	if templateSet {
-		defer unsetEnv("SKYTAP_TEMPLATE_ID")
-	}
-	if vmSet {
-		defer unsetEnv("SKYTAP_VM_ID")
-	}
+	templateID, vmID, newEnvTemplateID := setupEnvironment("1473407", "37865463")
 	uniqueSuffixEnv := acctest.RandInt()
 	var vm skytap.VM
 	var vmUpdated skytap.VM
@@ -202,7 +177,7 @@ func TestAccSkytapVMCPURAM_UpdateNPECheck(t *testing.T) {
 		CheckDestroy: testAccCheckSkytapEnvironmentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSkytapVMConfig_basic(newEnvTemplateID, uniqueSuffixEnv, "", os.Getenv("SKYTAP_TEMPLATE_ID"), os.Getenv("SKYTAP_VM_ID"), "", "",
+				Config: testAccSkytapVMConfig_basic(newEnvTemplateID, uniqueSuffixEnv, "", templateID, vmID, "", "",
 					``),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSkytapVMExists("skytap_environment.foo", "skytap_vm.bar", &vm),
@@ -212,7 +187,7 @@ func TestAccSkytapVMCPURAM_UpdateNPECheck(t *testing.T) {
 			},
 			{
 				PreConfig: pause(),
-				Config: testAccSkytapVMConfig_basic(newEnvTemplateID, uniqueSuffixEnv, "", os.Getenv("SKYTAP_TEMPLATE_ID"), os.Getenv("SKYTAP_VM_ID"), "", "",
+				Config: testAccSkytapVMConfig_basic(newEnvTemplateID, uniqueSuffixEnv, "", templateID, vmID, "", "",
 					`"cpus" = 8
 									"ram" = 2048`),
 				Check: resource.ComposeTestCheckFunc(
@@ -226,13 +201,7 @@ func TestAccSkytapVMCPURAM_UpdateNPECheck(t *testing.T) {
 func TestAccSkytapVMCPURAM_Invalid(t *testing.T) {
 	//t.Parallel()
 
-	templateSet, vmSet, newEnvTemplateID := setupEnvironment(t, "1473407", "37865463")
-	if templateSet {
-		defer unsetEnv("SKYTAP_TEMPLATE_ID")
-	}
-	if vmSet {
-		defer unsetEnv("SKYTAP_VM_ID")
-	}
+	templateID, vmID, newEnvTemplateID := setupEnvironment("1473407", "37865463")
 	uniqueSuffixEnv := acctest.RandInt()
 
 	resource.Test(t, resource.TestCase{
@@ -241,7 +210,7 @@ func TestAccSkytapVMCPURAM_Invalid(t *testing.T) {
 		CheckDestroy: testAccCheckSkytapEnvironmentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSkytapVMConfig_basic(newEnvTemplateID, uniqueSuffixEnv, "", os.Getenv("SKYTAP_TEMPLATE_ID"), os.Getenv("SKYTAP_VM_ID"), "", "",
+				Config: testAccSkytapVMConfig_basic(newEnvTemplateID, uniqueSuffixEnv, "", templateID, vmID, "", "",
 					`"cpus" = 121
 									"ram" = 819000000002`),
 				ExpectError: regexp.MustCompile(`config is invalid: 2 problems:*`),
@@ -253,13 +222,7 @@ func TestAccSkytapVMCPURAM_Invalid(t *testing.T) {
 func TestAccSkytapVMCPU_OutOfRange(t *testing.T) {
 	//t.Parallel()
 
-	templateSet, vmSet, newEnvTemplateID := setupEnvironment(t, "136409", "849656")
-	if templateSet {
-		defer unsetEnv("SKYTAP_TEMPLATE_ID")
-	}
-	if vmSet {
-		defer unsetEnv("SKYTAP_VM_ID")
-	}
+	templateID, vmID, newEnvTemplateID := setupEnvironmentWithKeys("SKYTAP_TEMPLATE_OUTOFRANGE_ID","136409", "SKYTAP_VM_OUTOFRANGE_ID", "849656")
 	uniqueSuffixEnv := acctest.RandInt()
 
 	resource.Test(t, resource.TestCase{
@@ -268,7 +231,7 @@ func TestAccSkytapVMCPU_OutOfRange(t *testing.T) {
 		CheckDestroy: testAccCheckSkytapEnvironmentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSkytapVMConfig_basic(newEnvTemplateID, uniqueSuffixEnv, "", os.Getenv("SKYTAP_TEMPLATE_ID"), os.Getenv("SKYTAP_VM_ID"), "", "",
+				Config: testAccSkytapVMConfig_basic(newEnvTemplateID, uniqueSuffixEnv, "", templateID, vmID, "", "",
 					`"cpus" = 12
 									"ram" = 131072`),
 				ExpectError: regexp.MustCompile(`the 'cpus' argument has been assigned \(12\) which is more than the maximum allowed \(8\) as defined by this VM`),
@@ -280,13 +243,7 @@ func TestAccSkytapVMCPU_OutOfRange(t *testing.T) {
 func TestAccSkytapVMCPU_OutOfRangeAfterUpdate(t *testing.T) {
 	//t.Parallel()
 
-	templateSet, vmSet, newEnvTemplateID := setupEnvironment(t, "136409", "849656")
-	if templateSet {
-		defer unsetEnv("SKYTAP_TEMPLATE_ID")
-	}
-	if vmSet {
-		defer unsetEnv("SKYTAP_VM_ID")
-	}
+	templateID, vmID, newEnvTemplateID := setupEnvironmentWithKeys("SKYTAP_TEMPLATE_OUTOFRANGE_ID","136409", "SKYTAP_VM_OUTOFRANGE_ID", "849656")
 	uniqueSuffixEnv := acctest.RandInt()
 
 	resource.Test(t, resource.TestCase{
@@ -295,11 +252,11 @@ func TestAccSkytapVMCPU_OutOfRangeAfterUpdate(t *testing.T) {
 		CheckDestroy: testAccCheckSkytapEnvironmentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSkytapVMConfig_basic(newEnvTemplateID, uniqueSuffixEnv, "", os.Getenv("SKYTAP_TEMPLATE_ID"), os.Getenv("SKYTAP_VM_ID"), "", "",
+				Config: testAccSkytapVMConfig_basic(newEnvTemplateID, uniqueSuffixEnv, "", templateID, vmID, "", "",
 					``),
 			},
 			{
-				Config: testAccSkytapVMConfig_basic(newEnvTemplateID, uniqueSuffixEnv, "", os.Getenv("SKYTAP_TEMPLATE_ID"), os.Getenv("SKYTAP_VM_ID"), "", "",
+				Config: testAccSkytapVMConfig_basic(newEnvTemplateID, uniqueSuffixEnv, "", templateID, vmID, "", "",
 					`"cpus" = 12
 									"ram" = 131072`),
 				ExpectError: regexp.MustCompile(`the 'cpus' argument has been assigned \(12\) which is more than the maximum allowed \(8\) as defined by this VM`),
@@ -311,13 +268,7 @@ func TestAccSkytapVMCPU_OutOfRangeAfterUpdate(t *testing.T) {
 func TestAccSkytapVMDisks_Create(t *testing.T) {
 	//t.Parallel()
 
-	templateSet, vmSet, newEnvTemplateID := setupEnvironment(t, "136409", "849656")
-	if templateSet {
-		defer unsetEnv("SKYTAP_TEMPLATE_ID")
-	}
-	if vmSet {
-		defer unsetEnv("SKYTAP_VM_ID")
-	}
+	templateID, vmID, newEnvTemplateID := setupEnvironment("1473407", "37865463")
 	uniqueSuffixEnv := acctest.RandInt()
 	var vm skytap.VM
 	var vmUpdated skytap.VM
@@ -328,7 +279,7 @@ func TestAccSkytapVMDisks_Create(t *testing.T) {
 		CheckDestroy: testAccCheckSkytapEnvironmentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSkytapVMConfig_basic(newEnvTemplateID, uniqueSuffixEnv, "", os.Getenv("SKYTAP_TEMPLATE_ID"), os.Getenv("SKYTAP_VM_ID"), "", "",
+				Config: testAccSkytapVMConfig_basic(newEnvTemplateID, uniqueSuffixEnv, "", templateID, vmID, "", "",
 					`"disk" = {
 										"size" = 2048
 										"name" = "smaller"
@@ -349,7 +300,7 @@ func TestAccSkytapVMDisks_Create(t *testing.T) {
 			},
 			{
 				PreConfig: pause(),
-				Config: testAccSkytapVMConfig_basic(newEnvTemplateID, uniqueSuffixEnv, "", os.Getenv("SKYTAP_TEMPLATE_ID"), os.Getenv("SKYTAP_VM_ID"), "", "",
+				Config: testAccSkytapVMConfig_basic(newEnvTemplateID, uniqueSuffixEnv, "", templateID, vmID, "", "",
 					`"disk" = {
 										"size" = 2048
 										"name" = "smaller2"  # stays the same
@@ -373,13 +324,7 @@ func TestAccSkytapVMDisks_Create(t *testing.T) {
 func TestAccSkytapVMDisks_UpdateNPECheck(t *testing.T) {
 	//t.Parallel()
 
-	templateSet, vmSet, newEnvTemplateID := setupEnvironment(t, "136409", "849656")
-	if templateSet {
-		defer unsetEnv("SKYTAP_TEMPLATE_ID")
-	}
-	if vmSet {
-		defer unsetEnv("SKYTAP_VM_ID")
-	}
+	templateID, vmID, newEnvTemplateID := setupEnvironment("1473407", "37865463")
 	uniqueSuffixEnv := acctest.RandInt()
 	var vm skytap.VM
 	var vmUpdated skytap.VM
@@ -390,7 +335,7 @@ func TestAccSkytapVMDisks_UpdateNPECheck(t *testing.T) {
 		CheckDestroy: testAccCheckSkytapEnvironmentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSkytapVMConfig_basic(newEnvTemplateID, uniqueSuffixEnv, "", os.Getenv("SKYTAP_TEMPLATE_ID"), os.Getenv("SKYTAP_VM_ID"), "", "",
+				Config: testAccSkytapVMConfig_basic(newEnvTemplateID, uniqueSuffixEnv, "", templateID, vmID, "", "",
 					``),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSkytapVMExists("skytap_environment.foo", "skytap_vm.bar", &vm),
@@ -398,7 +343,7 @@ func TestAccSkytapVMDisks_UpdateNPECheck(t *testing.T) {
 			},
 			{
 				PreConfig: pause(),
-				Config: testAccSkytapVMConfig_basic(newEnvTemplateID, uniqueSuffixEnv, "", os.Getenv("SKYTAP_TEMPLATE_ID"), os.Getenv("SKYTAP_VM_ID"), "", "",
+				Config: testAccSkytapVMConfig_basic(newEnvTemplateID, uniqueSuffixEnv, "", templateID, vmID, "", "",
 					`"disk" = {
 										"size" = 8000
 										"name" = "smaller"
@@ -417,13 +362,7 @@ func TestAccSkytapVMDisks_UpdateNPECheck(t *testing.T) {
 func TestAccSkytapVMDisks_Resize(t *testing.T) {
 	//t.Parallel()
 
-	templateSet, vmSet, newEnvTemplateID := setupEnvironment(t, "136409", "849656")
-	if templateSet {
-		defer unsetEnv("SKYTAP_TEMPLATE_ID")
-	}
-	if vmSet {
-		defer unsetEnv("SKYTAP_VM_ID")
-	}
+	templateID, vmID, newEnvTemplateID := setupEnvironment("1473407", "37865463")
 	uniqueSuffixEnv := acctest.RandInt()
 	var vm skytap.VM
 	var vmUpdated skytap.VM
@@ -434,7 +373,7 @@ func TestAccSkytapVMDisks_Resize(t *testing.T) {
 		CheckDestroy: testAccCheckSkytapEnvironmentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSkytapVMConfig_basic(newEnvTemplateID, uniqueSuffixEnv, "", os.Getenv("SKYTAP_TEMPLATE_ID"), os.Getenv("SKYTAP_VM_ID"), "", "",
+				Config: testAccSkytapVMConfig_basic(newEnvTemplateID, uniqueSuffixEnv, "", templateID, vmID, "", "",
 					`"disk" = {
 										"size" = 8000
 										"name" = "smaller"
@@ -447,7 +386,7 @@ func TestAccSkytapVMDisks_Resize(t *testing.T) {
 			},
 			{
 				PreConfig: pause(),
-				Config: testAccSkytapVMConfig_basic(newEnvTemplateID, uniqueSuffixEnv, "", os.Getenv("SKYTAP_TEMPLATE_ID"), os.Getenv("SKYTAP_VM_ID"), "", "",
+				Config: testAccSkytapVMConfig_basic(newEnvTemplateID, uniqueSuffixEnv, "", templateID, vmID, "", "",
 					`"disk" = {
 										"size" = 8192
 										"name" = "smaller"
@@ -460,7 +399,7 @@ func TestAccSkytapVMDisks_Resize(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccSkytapVMConfig_basic(newEnvTemplateID, uniqueSuffixEnv, "", os.Getenv("SKYTAP_TEMPLATE_ID"), os.Getenv("SKYTAP_VM_ID"), "", "",
+				Config: testAccSkytapVMConfig_basic(newEnvTemplateID, uniqueSuffixEnv, "", templateID, vmID, "", "",
 					`"disk" = {
 										"size" = 6000
 										"name" = "smaller"
@@ -474,13 +413,7 @@ func TestAccSkytapVMDisks_Resize(t *testing.T) {
 func TestAccSkytapVMDisk_Invalid(t *testing.T) {
 	//t.Parallel()
 
-	templateSet, vmSet, newEnvTemplateID := setupEnvironment(t, "1473407", "37865463")
-	if templateSet {
-		defer unsetEnv("SKYTAP_TEMPLATE_ID")
-	}
-	if vmSet {
-		defer unsetEnv("SKYTAP_VM_ID")
-	}
+	templateID, vmID, newEnvTemplateID := setupEnvironment("1473407", "37865463")
 	uniqueSuffixEnv := acctest.RandInt()
 
 	resource.Test(t, resource.TestCase{
@@ -489,7 +422,7 @@ func TestAccSkytapVMDisk_Invalid(t *testing.T) {
 		CheckDestroy: testAccCheckSkytapEnvironmentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSkytapVMConfig_basic(newEnvTemplateID, uniqueSuffixEnv, "", os.Getenv("SKYTAP_TEMPLATE_ID"), os.Getenv("SKYTAP_VM_ID"), "", "",
+				Config: testAccSkytapVMConfig_basic(newEnvTemplateID, uniqueSuffixEnv, "", templateID, vmID, "", "",
 					`"disk" = {
 										"size" = 2047
 										"name" = "too small"
@@ -497,7 +430,7 @@ func TestAccSkytapVMDisk_Invalid(t *testing.T) {
 				ExpectError: regexp.MustCompile(`config is invalid: skytap_vm.bar: expected disk.0.size to be in the range \(2048 - 2096128\), got 2047`),
 			},
 			{
-				Config: testAccSkytapVMConfig_basic(newEnvTemplateID, uniqueSuffixEnv, "", os.Getenv("SKYTAP_TEMPLATE_ID"), os.Getenv("SKYTAP_VM_ID"), "", "",
+				Config: testAccSkytapVMConfig_basic(newEnvTemplateID, uniqueSuffixEnv, "", templateID, vmID, "", "",
 					`"disk" = {
 										"size" = 2096129
 										"name" = "too big"
@@ -511,13 +444,7 @@ func TestAccSkytapVMDisk_Invalid(t *testing.T) {
 func TestAccSkytapVMDisk_OS(t *testing.T) {
 	//t.Parallel()
 
-	templateSet, vmSet, newEnvTemplateID := setupEnvironment(t, "1473407", "37865463")
-	if templateSet {
-		defer unsetEnv("SKYTAP_TEMPLATE_ID")
-	}
-	if vmSet {
-		defer unsetEnv("SKYTAP_VM_ID")
-	}
+	templateID, vmID, newEnvTemplateID := setupEnvironment("1473407", "37865463")
 	uniqueSuffixEnv := acctest.RandInt()
 	var vm skytap.VM
 	var vmUpdated skytap.VM
@@ -528,7 +455,7 @@ func TestAccSkytapVMDisk_OS(t *testing.T) {
 		CheckDestroy: testAccCheckSkytapEnvironmentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSkytapVMConfig_basic(newEnvTemplateID, uniqueSuffixEnv, "", os.Getenv("SKYTAP_TEMPLATE_ID"), os.Getenv("SKYTAP_VM_ID"), "", "",
+				Config: testAccSkytapVMConfig_basic(newEnvTemplateID, uniqueSuffixEnv, "", templateID, vmID, "", "",
 					`"os_disk_size" = 30721`),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSkytapVMExists("skytap_environment.foo", "skytap_vm.bar", &vm),
@@ -540,7 +467,7 @@ func TestAccSkytapVMDisk_OS(t *testing.T) {
 			},
 			{
 				PreConfig: pause(),
-				Config: testAccSkytapVMConfig_basic(newEnvTemplateID, uniqueSuffixEnv, "", os.Getenv("SKYTAP_TEMPLATE_ID"), os.Getenv("SKYTAP_VM_ID"), "", "",
+				Config: testAccSkytapVMConfig_basic(newEnvTemplateID, uniqueSuffixEnv, "", templateID, vmID, "", "",
 					`"os_disk_size" = 30722`),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSkytapVMExists("skytap_environment.foo", "skytap_vm.bar", &vmUpdated),
@@ -550,7 +477,7 @@ func TestAccSkytapVMDisk_OS(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccSkytapVMConfig_basic(newEnvTemplateID, uniqueSuffixEnv, "", os.Getenv("SKYTAP_TEMPLATE_ID"), os.Getenv("SKYTAP_VM_ID"), "", "",
+				Config: testAccSkytapVMConfig_basic(newEnvTemplateID, uniqueSuffixEnv, "", templateID, vmID, "", "",
 					`"os_disk_size" = 3000`),
 				ExpectError: regexp.MustCompile(`cannot shrink volume \(OS\) from size \(30722\) to size \(3000\)`),
 			},
@@ -561,13 +488,7 @@ func TestAccSkytapVMDisk_OS(t *testing.T) {
 func TestAccSkytapVMDisk_OSChangeAfter(t *testing.T) {
 	//t.Parallel()
 
-	templateSet, vmSet, newEnvTemplateID := setupEnvironment(t, "1473407", "37865463")
-	if templateSet {
-		defer unsetEnv("SKYTAP_TEMPLATE_ID")
-	}
-	if vmSet {
-		defer unsetEnv("SKYTAP_VM_ID")
-	}
+	templateID, vmID, newEnvTemplateID := setupEnvironment("1473407", "37865463")
 	uniqueSuffixEnv := acctest.RandInt()
 	var vm skytap.VM
 	var vmUpdated skytap.VM
@@ -578,7 +499,7 @@ func TestAccSkytapVMDisk_OSChangeAfter(t *testing.T) {
 		CheckDestroy: testAccCheckSkytapEnvironmentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSkytapVMConfig_basic(newEnvTemplateID, uniqueSuffixEnv, "", os.Getenv("SKYTAP_TEMPLATE_ID"), os.Getenv("SKYTAP_VM_ID"), "", "",
+				Config: testAccSkytapVMConfig_basic(newEnvTemplateID, uniqueSuffixEnv, "", templateID, vmID, "", "",
 					``),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSkytapVMExists("skytap_environment.foo", "skytap_vm.bar", &vm),
@@ -587,7 +508,7 @@ func TestAccSkytapVMDisk_OSChangeAfter(t *testing.T) {
 			},
 			{
 				PreConfig: pause(),
-				Config: testAccSkytapVMConfig_basic(newEnvTemplateID, uniqueSuffixEnv, "", os.Getenv("SKYTAP_TEMPLATE_ID"), os.Getenv("SKYTAP_VM_ID"), "", "",
+				Config: testAccSkytapVMConfig_basic(newEnvTemplateID, uniqueSuffixEnv, "", templateID, vmID, "", "",
 					`"os_disk_size" = 30721`),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSkytapVMExists("skytap_environment.foo", "skytap_vm.bar", &vmUpdated),

--- a/skytap/resource_skytap_vm_hardware_test.go
+++ b/skytap/resource_skytap_vm_hardware_test.go
@@ -2,7 +2,6 @@ package skytap
 
 import (
 	"fmt"
-	"log"
 	"os"
 	"regexp"
 	"sort"
@@ -18,20 +17,12 @@ import (
 func TestAccSkytapVMCPURam_Create(t *testing.T) {
 	//t.Parallel()
 
-	if os.Getenv("SKYTAP_TEMPLATE_ID") == "" {
-		log.Printf("[WARN] SKYTAP_TEMPLATE_ID required to run skytap_vm_resource acceptance tests. Setting: SKYTAP_TEMPLATE_ID=136409")
-		err := os.Setenv("SKYTAP_TEMPLATE_ID", "136409")
-		assert.NoError(t, err)
+	templateSet, vmSet, newEnvTemplateID := setupEnvironment(t, "136409", "849656")
+	if templateSet {
+		defer unsetEnv("SKYTAP_TEMPLATE_ID")
 	}
-	if os.Getenv("SKYTAP_VM_ID") == "" {
-		log.Printf("[WARN] SKYTAP_VM_ID required to run skytap_vm_resource acceptance tests. Setting: SKYTAP_VM_ID=849656")
-		err := os.Setenv("SKYTAP_VM_ID", "849656")
-		assert.NoError(t, err)
-	}
-	newEnvTemplateID := os.Getenv("SKYTAP_TEMPLATE_ID")
-	if os.Getenv("SKYTAP_TEMPLATE_NEW_ENV_ID") != "" {
-		newEnvTemplateID = os.Getenv("SKYTAP_TEMPLATE_NEW_ENV_ID")
-		log.Printf("[DEBUG] SKYTAP_TEMPLATE_NEW_ENV_ID=%s", newEnvTemplateID)
+	if vmSet {
+		defer unsetEnv("SKYTAP_VM_ID")
 	}
 	uniqueSuffixEnv := acctest.RandInt()
 	var vm skytap.VM
@@ -80,20 +71,12 @@ func TestAccSkytapVMCPURam_Create(t *testing.T) {
 func TestAccSkytapVMCPU_DiskIntact(t *testing.T) {
 	//t.Parallel()
 
-	if os.Getenv("SKYTAP_TEMPLATE_ID") == "" {
-		log.Printf("[WARN] SKYTAP_TEMPLATE_ID required to run skytap_vm_resource acceptance tests. Setting: SKYTAP_TEMPLATE_ID=136409")
-		err := os.Setenv("SKYTAP_TEMPLATE_ID", "136409")
-		assert.NoError(t, err)
+	templateSet, vmSet, newEnvTemplateID := setupEnvironment(t, "136409", "849656")
+	if templateSet {
+		defer unsetEnv("SKYTAP_TEMPLATE_ID")
 	}
-	if os.Getenv("SKYTAP_VM_ID") == "" {
-		log.Printf("[WARN] SKYTAP_VM_ID required to run skytap_vm_resource acceptance tests. Setting: SKYTAP_VM_ID=849656")
-		err := os.Setenv("SKYTAP_VM_ID", "849656")
-		assert.NoError(t, err)
-	}
-	newEnvTemplateID := os.Getenv("SKYTAP_TEMPLATE_ID")
-	if os.Getenv("SKYTAP_TEMPLATE_NEW_ENV_ID") != "" {
-		newEnvTemplateID = os.Getenv("SKYTAP_TEMPLATE_NEW_ENV_ID")
-		log.Printf("[DEBUG] SKYTAP_TEMPLATE_NEW_ENV_ID=%s", newEnvTemplateID)
+	if vmSet {
+		defer unsetEnv("SKYTAP_VM_ID")
 	}
 	uniqueSuffixEnv := acctest.RandInt()
 	var vm skytap.VM
@@ -141,20 +124,12 @@ func TestAccSkytapVMCPU_DiskIntact(t *testing.T) {
 func TestAccSkytapVMCPU_WithDisk(t *testing.T) {
 	//t.Parallel()
 
-	if os.Getenv("SKYTAP_TEMPLATE_ID") == "" {
-		log.Printf("[WARN] SKYTAP_TEMPLATE_ID required to run skytap_vm_resource acceptance tests. Setting: SKYTAP_TEMPLATE_ID=136409")
-		err := os.Setenv("SKYTAP_TEMPLATE_ID", "136409")
-		assert.NoError(t, err)
+	templateSet, vmSet, newEnvTemplateID := setupEnvironment(t, "136409", "849656")
+	if templateSet {
+		defer unsetEnv("SKYTAP_TEMPLATE_ID")
 	}
-	if os.Getenv("SKYTAP_VM_ID") == "" {
-		log.Printf("[WARN] SKYTAP_VM_ID required to run skytap_vm_resource acceptance tests. Setting: SKYTAP_VM_ID=849656")
-		err := os.Setenv("SKYTAP_VM_ID", "849656")
-		assert.NoError(t, err)
-	}
-	newEnvTemplateID := os.Getenv("SKYTAP_TEMPLATE_ID")
-	if os.Getenv("SKYTAP_TEMPLATE_NEW_ENV_ID") != "" {
-		newEnvTemplateID = os.Getenv("SKYTAP_TEMPLATE_NEW_ENV_ID")
-		log.Printf("[DEBUG] SKYTAP_TEMPLATE_NEW_ENV_ID=%s", newEnvTemplateID)
+	if vmSet {
+		defer unsetEnv("SKYTAP_VM_ID")
 	}
 	uniqueSuffixEnv := acctest.RandInt()
 	var vm skytap.VM
@@ -201,20 +176,12 @@ func TestAccSkytapVMCPU_WithDisk(t *testing.T) {
 func TestAccSkytapVMCPURAM_UpdateNPECheck(t *testing.T) {
 	//t.Parallel()
 
-	if os.Getenv("SKYTAP_TEMPLATE_ID") == "" {
-		log.Printf("[WARN] SKYTAP_TEMPLATE_ID required to run skytap_vm_resource acceptance tests. Setting: SKYTAP_TEMPLATE_ID=136409")
-		err := os.Setenv("SKYTAP_TEMPLATE_ID", "136409")
-		assert.NoError(t, err)
+	templateSet, vmSet, newEnvTemplateID := setupEnvironment(t, "136409", "849656")
+	if templateSet {
+		defer unsetEnv("SKYTAP_TEMPLATE_ID")
 	}
-	if os.Getenv("SKYTAP_VM_ID") == "" {
-		log.Printf("[WARN] SKYTAP_VM_ID required to run skytap_vm_resource acceptance tests. Setting: SKYTAP_VM_ID=849656")
-		err := os.Setenv("SKYTAP_VM_ID", "849656")
-		assert.NoError(t, err)
-	}
-	newEnvTemplateID := os.Getenv("SKYTAP_TEMPLATE_ID")
-	if os.Getenv("SKYTAP_TEMPLATE_NEW_ENV_ID") != "" {
-		newEnvTemplateID = os.Getenv("SKYTAP_TEMPLATE_NEW_ENV_ID")
-		log.Printf("[DEBUG] SKYTAP_TEMPLATE_NEW_ENV_ID=%s", newEnvTemplateID)
+	if vmSet {
+		defer unsetEnv("SKYTAP_VM_ID")
 	}
 	uniqueSuffixEnv := acctest.RandInt()
 	var vm skytap.VM
@@ -249,20 +216,12 @@ func TestAccSkytapVMCPURAM_UpdateNPECheck(t *testing.T) {
 func TestAccSkytapVMCPURAM_Invalid(t *testing.T) {
 	//t.Parallel()
 
-	if os.Getenv("SKYTAP_TEMPLATE_ID") == "" {
-		log.Printf("[WARN] SKYTAP_TEMPLATE_ID required to run skytap_vm_resource acceptance tests. Setting: SKYTAP_TEMPLATE_ID=1473407")
-		err := os.Setenv("SKYTAP_TEMPLATE_ID", "1473407")
-		assert.NoError(t, err)
+	templateSet, vmSet, newEnvTemplateID := setupEnvironment(t, "1473407", "37865463")
+	if templateSet {
+		defer unsetEnv("SKYTAP_TEMPLATE_ID")
 	}
-	if os.Getenv("SKYTAP_VM_ID") == "" {
-		log.Printf("[WARN] SKYTAP_VM_ID required to run skytap_vm_resource acceptance tests. Setting: SKYTAP_VM_ID=37865463")
-		err := os.Setenv("SKYTAP_VM_ID", "37865463")
-		assert.NoError(t, err)
-	}
-	newEnvTemplateID := os.Getenv("SKYTAP_TEMPLATE_ID")
-	if os.Getenv("SKYTAP_TEMPLATE_NEW_ENV_ID") != "" {
-		newEnvTemplateID = os.Getenv("SKYTAP_TEMPLATE_NEW_ENV_ID")
-		log.Printf("[DEBUG] SKYTAP_TEMPLATE_NEW_ENV_ID=%s", newEnvTemplateID)
+	if vmSet {
+		defer unsetEnv("SKYTAP_VM_ID")
 	}
 	uniqueSuffixEnv := acctest.RandInt()
 
@@ -284,20 +243,12 @@ func TestAccSkytapVMCPURAM_Invalid(t *testing.T) {
 func TestAccSkytapVMCPU_OutOfRange(t *testing.T) {
 	//t.Parallel()
 
-	if os.Getenv("SKYTAP_TEMPLATE_ID") == "" {
-		log.Printf("[WARN] SKYTAP_TEMPLATE_ID required to run skytap_vm_resource acceptance tests. Setting: SKYTAP_TEMPLATE_ID=136409")
-		err := os.Setenv("SKYTAP_TEMPLATE_ID", "136409")
-		assert.NoError(t, err)
+	templateSet, vmSet, newEnvTemplateID := setupEnvironment(t, "136409", "849656")
+	if templateSet {
+		defer unsetEnv("SKYTAP_TEMPLATE_ID")
 	}
-	if os.Getenv("SKYTAP_VM_ID") == "" {
-		log.Printf("[WARN] SKYTAP_VM_ID required to run skytap_vm_resource acceptance tests. Setting: SKYTAP_VM_ID=849656")
-		err := os.Setenv("SKYTAP_VM_ID", "849656")
-		assert.NoError(t, err)
-	}
-	newEnvTemplateID := os.Getenv("SKYTAP_TEMPLATE_ID")
-	if os.Getenv("SKYTAP_TEMPLATE_NEW_ENV_ID") != "" {
-		newEnvTemplateID = os.Getenv("SKYTAP_TEMPLATE_NEW_ENV_ID")
-		log.Printf("[DEBUG] SKYTAP_TEMPLATE_NEW_ENV_ID=%s", newEnvTemplateID)
+	if vmSet {
+		defer unsetEnv("SKYTAP_VM_ID")
 	}
 	uniqueSuffixEnv := acctest.RandInt()
 
@@ -319,20 +270,12 @@ func TestAccSkytapVMCPU_OutOfRange(t *testing.T) {
 func TestAccSkytapVMCPU_OutOfRangeAfterUpdate(t *testing.T) {
 	//t.Parallel()
 
-	if os.Getenv("SKYTAP_TEMPLATE_ID") == "" {
-		log.Printf("[WARN] SKYTAP_TEMPLATE_ID required to run skytap_vm_resource acceptance tests. Setting: SKYTAP_TEMPLATE_ID=136409")
-		err := os.Setenv("SKYTAP_TEMPLATE_ID", "136409")
-		assert.NoError(t, err)
+	templateSet, vmSet, newEnvTemplateID := setupEnvironment(t, "136409", "849656")
+	if templateSet {
+		defer unsetEnv("SKYTAP_TEMPLATE_ID")
 	}
-	if os.Getenv("SKYTAP_VM_ID") == "" {
-		log.Printf("[WARN] SKYTAP_VM_ID required to run skytap_vm_resource acceptance tests. Setting: SKYTAP_VM_ID=849656")
-		err := os.Setenv("SKYTAP_VM_ID", "849656")
-		assert.NoError(t, err)
-	}
-	newEnvTemplateID := os.Getenv("SKYTAP_TEMPLATE_ID")
-	if os.Getenv("SKYTAP_TEMPLATE_NEW_ENV_ID") != "" {
-		newEnvTemplateID = os.Getenv("SKYTAP_TEMPLATE_NEW_ENV_ID")
-		log.Printf("[DEBUG] SKYTAP_TEMPLATE_NEW_ENV_ID=%s", newEnvTemplateID)
+	if vmSet {
+		defer unsetEnv("SKYTAP_VM_ID")
 	}
 	uniqueSuffixEnv := acctest.RandInt()
 
@@ -358,20 +301,12 @@ func TestAccSkytapVMCPU_OutOfRangeAfterUpdate(t *testing.T) {
 func TestAccSkytapVMDisks_Create(t *testing.T) {
 	//t.Parallel()
 
-	if os.Getenv("SKYTAP_TEMPLATE_ID") == "" {
-		log.Printf("[WARN] SKYTAP_TEMPLATE_ID required to run skytap_vm_resource acceptance tests. Setting: SKYTAP_TEMPLATE_ID=136409")
-		err := os.Setenv("SKYTAP_TEMPLATE_ID", "136409")
-		assert.NoError(t, err)
+	templateSet, vmSet, newEnvTemplateID := setupEnvironment(t, "136409", "849656")
+	if templateSet {
+		defer unsetEnv("SKYTAP_TEMPLATE_ID")
 	}
-	if os.Getenv("SKYTAP_VM_ID") == "" {
-		log.Printf("[WARN] SKYTAP_VM_ID required to run skytap_vm_resource acceptance tests. Setting: SKYTAP_VM_ID=849656")
-		err := os.Setenv("SKYTAP_VM_ID", "849656")
-		assert.NoError(t, err)
-	}
-	newEnvTemplateID := os.Getenv("SKYTAP_TEMPLATE_ID")
-	if os.Getenv("SKYTAP_TEMPLATE_NEW_ENV_ID") != "" {
-		newEnvTemplateID = os.Getenv("SKYTAP_TEMPLATE_NEW_ENV_ID")
-		log.Printf("[DEBUG] SKYTAP_TEMPLATE_NEW_ENV_ID=%s", newEnvTemplateID)
+	if vmSet {
+		defer unsetEnv("SKYTAP_VM_ID")
 	}
 	uniqueSuffixEnv := acctest.RandInt()
 	var vm skytap.VM
@@ -427,20 +362,12 @@ func TestAccSkytapVMDisks_Create(t *testing.T) {
 func TestAccSkytapVMDisks_UpdateNPECheck(t *testing.T) {
 	//t.Parallel()
 
-	if os.Getenv("SKYTAP_TEMPLATE_ID") == "" {
-		log.Printf("[WARN] SKYTAP_TEMPLATE_ID required to run skytap_vm_resource acceptance tests. Setting: SKYTAP_TEMPLATE_ID=136409")
-		err := os.Setenv("SKYTAP_TEMPLATE_ID", "136409")
-		assert.NoError(t, err)
+	templateSet, vmSet, newEnvTemplateID := setupEnvironment(t, "136409", "849656")
+	if templateSet {
+		defer unsetEnv("SKYTAP_TEMPLATE_ID")
 	}
-	if os.Getenv("SKYTAP_VM_ID") == "" {
-		log.Printf("[WARN] SKYTAP_VM_ID required to run skytap_vm_resource acceptance tests. Setting: SKYTAP_VM_ID=849656")
-		err := os.Setenv("SKYTAP_VM_ID", "849656")
-		assert.NoError(t, err)
-	}
-	newEnvTemplateID := os.Getenv("SKYTAP_TEMPLATE_ID")
-	if os.Getenv("SKYTAP_TEMPLATE_NEW_ENV_ID") != "" {
-		newEnvTemplateID = os.Getenv("SKYTAP_TEMPLATE_NEW_ENV_ID")
-		log.Printf("[DEBUG] SKYTAP_TEMPLATE_NEW_ENV_ID=%s", newEnvTemplateID)
+	if vmSet {
+		defer unsetEnv("SKYTAP_VM_ID")
 	}
 	uniqueSuffixEnv := acctest.RandInt()
 	var vm skytap.VM
@@ -478,20 +405,12 @@ func TestAccSkytapVMDisks_UpdateNPECheck(t *testing.T) {
 func TestAccSkytapVMDisks_Resize(t *testing.T) {
 	//t.Parallel()
 
-	if os.Getenv("SKYTAP_TEMPLATE_ID") == "" {
-		log.Printf("[WARN] SKYTAP_TEMPLATE_ID required to run skytap_vm_resource acceptance tests. Setting: SKYTAP_TEMPLATE_ID=136409")
-		err := os.Setenv("SKYTAP_TEMPLATE_ID", "136409")
-		assert.NoError(t, err)
+	templateSet, vmSet, newEnvTemplateID := setupEnvironment(t, "136409", "849656")
+	if templateSet {
+		defer unsetEnv("SKYTAP_TEMPLATE_ID")
 	}
-	if os.Getenv("SKYTAP_VM_ID") == "" {
-		log.Printf("[WARN] SKYTAP_VM_ID required to run skytap_vm_resource acceptance tests. Setting: SKYTAP_VM_ID=849656")
-		err := os.Setenv("SKYTAP_VM_ID", "849656")
-		assert.NoError(t, err)
-	}
-	newEnvTemplateID := os.Getenv("SKYTAP_TEMPLATE_ID")
-	if os.Getenv("SKYTAP_TEMPLATE_NEW_ENV_ID") != "" {
-		newEnvTemplateID = os.Getenv("SKYTAP_TEMPLATE_NEW_ENV_ID")
-		log.Printf("[DEBUG] SKYTAP_TEMPLATE_NEW_ENV_ID=%s", newEnvTemplateID)
+	if vmSet {
+		defer unsetEnv("SKYTAP_VM_ID")
 	}
 	uniqueSuffixEnv := acctest.RandInt()
 	var vm skytap.VM
@@ -542,20 +461,12 @@ func TestAccSkytapVMDisks_Resize(t *testing.T) {
 func TestAccSkytapVMDisk_Invalid(t *testing.T) {
 	//t.Parallel()
 
-	if os.Getenv("SKYTAP_TEMPLATE_ID") == "" {
-		log.Printf("[WARN] SKYTAP_TEMPLATE_ID required to run skytap_vm_resource acceptance tests. Setting: SKYTAP_TEMPLATE_ID=1473407")
-		err := os.Setenv("SKYTAP_TEMPLATE_ID", "1473407")
-		assert.NoError(t, err)
+	templateSet, vmSet, newEnvTemplateID := setupEnvironment(t, "1473407", "37865463")
+	if templateSet {
+		defer unsetEnv("SKYTAP_TEMPLATE_ID")
 	}
-	if os.Getenv("SKYTAP_VM_ID") == "" {
-		log.Printf("[WARN] SKYTAP_VM_ID required to run skytap_vm_resource acceptance tests. Setting: SKYTAP_VM_ID=37865463")
-		err := os.Setenv("SKYTAP_VM_ID", "37865463")
-		assert.NoError(t, err)
-	}
-	newEnvTemplateID := os.Getenv("SKYTAP_TEMPLATE_ID")
-	if os.Getenv("SKYTAP_TEMPLATE_NEW_ENV_ID") != "" {
-		newEnvTemplateID = os.Getenv("SKYTAP_TEMPLATE_NEW_ENV_ID")
-		log.Printf("[DEBUG] SKYTAP_TEMPLATE_NEW_ENV_ID=%s", newEnvTemplateID)
+	if vmSet {
+		defer unsetEnv("SKYTAP_VM_ID")
 	}
 	uniqueSuffixEnv := acctest.RandInt()
 
@@ -587,20 +498,12 @@ func TestAccSkytapVMDisk_Invalid(t *testing.T) {
 func TestAccSkytapVMDisk_OS(t *testing.T) {
 	//t.Parallel()
 
-	if os.Getenv("SKYTAP_TEMPLATE_ID") == "" {
-		log.Printf("[WARN] SKYTAP_TEMPLATE_ID required to run skytap_vm_resource acceptance tests. Setting: SKYTAP_TEMPLATE_ID=1473407")
-		err := os.Setenv("SKYTAP_TEMPLATE_ID", "1473407")
-		assert.NoError(t, err)
+	templateSet, vmSet, newEnvTemplateID := setupEnvironment(t, "1473407", "37865463")
+	if templateSet {
+		defer unsetEnv("SKYTAP_TEMPLATE_ID")
 	}
-	if os.Getenv("SKYTAP_VM_ID") == "" {
-		log.Printf("[WARN] SKYTAP_VM_ID required to run skytap_vm_resource acceptance tests. Setting: SKYTAP_VM_ID=37865463")
-		err := os.Setenv("SKYTAP_VM_ID", "37865463")
-		assert.NoError(t, err)
-	}
-	newEnvTemplateID := os.Getenv("SKYTAP_TEMPLATE_ID")
-	if os.Getenv("SKYTAP_TEMPLATE_NEW_ENV_ID") != "" {
-		newEnvTemplateID = os.Getenv("SKYTAP_TEMPLATE_NEW_ENV_ID")
-		log.Printf("[DEBUG] SKYTAP_TEMPLATE_NEW_ENV_ID=%s", newEnvTemplateID)
+	if vmSet {
+		defer unsetEnv("SKYTAP_VM_ID")
 	}
 	uniqueSuffixEnv := acctest.RandInt()
 	var vm skytap.VM
@@ -644,20 +547,12 @@ func TestAccSkytapVMDisk_OS(t *testing.T) {
 func TestAccSkytapVMDisk_OSChangeAfter(t *testing.T) {
 	//t.Parallel()
 
-	if os.Getenv("SKYTAP_TEMPLATE_ID") == "" {
-		log.Printf("[WARN] SKYTAP_TEMPLATE_ID required to run skytap_vm_resource acceptance tests. Setting: SKYTAP_TEMPLATE_ID=1473407")
-		err := os.Setenv("SKYTAP_TEMPLATE_ID", "1473407")
-		assert.NoError(t, err)
+	templateSet, vmSet, newEnvTemplateID := setupEnvironment(t, "1473407", "37865463")
+	if templateSet {
+		defer unsetEnv("SKYTAP_TEMPLATE_ID")
 	}
-	if os.Getenv("SKYTAP_VM_ID") == "" {
-		log.Printf("[WARN] SKYTAP_VM_ID required to run skytap_vm_resource acceptance tests. Setting: SKYTAP_VM_ID=37865463")
-		err := os.Setenv("SKYTAP_VM_ID", "37865463")
-		assert.NoError(t, err)
-	}
-	newEnvTemplateID := os.Getenv("SKYTAP_TEMPLATE_ID")
-	if os.Getenv("SKYTAP_TEMPLATE_NEW_ENV_ID") != "" {
-		newEnvTemplateID = os.Getenv("SKYTAP_TEMPLATE_NEW_ENV_ID")
-		log.Printf("[DEBUG] SKYTAP_TEMPLATE_NEW_ENV_ID=%s", newEnvTemplateID)
+	if vmSet {
+		defer unsetEnv("SKYTAP_VM_ID")
 	}
 	uniqueSuffixEnv := acctest.RandInt()
 	var vm skytap.VM

--- a/skytap/resource_skytap_vm_hardware_test.go
+++ b/skytap/resource_skytap_vm_hardware_test.go
@@ -173,7 +173,7 @@ func TestAccSkytapVMCPURAM_Invalid(t *testing.T) {
 func TestAccSkytapVMCPU_OutOfRange(t *testing.T) {
 	//t.Parallel()
 
-	templateID, vmID, newEnvTemplateID := setupEnvironmentWithKeys("SKYTAP_TEMPLATE_OUTOFRANGE_ID","136409", "SKYTAP_VM_OUTOFRANGE_ID", "849656")
+	templateID, vmID, newEnvTemplateID := setupEnvironmentWithKeys("SKYTAP_TEMPLATE_OUTOFRANGE_ID", "136409", "SKYTAP_VM_OUTOFRANGE_ID", "849656")
 	uniqueSuffixEnv := acctest.RandInt()
 
 	resource.Test(t, resource.TestCase{
@@ -194,7 +194,7 @@ func TestAccSkytapVMCPU_OutOfRange(t *testing.T) {
 func TestAccSkytapVMCPU_OutOfRangeAfterUpdate(t *testing.T) {
 	//t.Parallel()
 
-	templateID, vmID, newEnvTemplateID := setupEnvironmentWithKeys("SKYTAP_TEMPLATE_OUTOFRANGE_ID","136409", "SKYTAP_VM_OUTOFRANGE_ID", "849656")
+	templateID, vmID, newEnvTemplateID := setupEnvironmentWithKeys("SKYTAP_TEMPLATE_OUTOFRANGE_ID", "136409", "SKYTAP_VM_OUTOFRANGE_ID", "849656")
 	uniqueSuffixEnv := acctest.RandInt()
 
 	resource.Test(t, resource.TestCase{

--- a/skytap/resource_skytap_vm_hardware_test.go
+++ b/skytap/resource_skytap_vm_hardware_test.go
@@ -6,6 +6,7 @@ import (
 	"regexp"
 	"sort"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
@@ -43,6 +44,7 @@ func TestAccSkytapVMCPURam_Create(t *testing.T) {
 				),
 			},
 			{
+				PreConfig: pause(),
 				Config: testAccSkytapVMConfig_basic(newEnvTemplateID, uniqueSuffixEnv, "", os.Getenv("SKYTAP_TEMPLATE_ID"), os.Getenv("SKYTAP_VM_ID"), "", "",
 					`"ram" = 8192`),
 				Check: resource.ComposeTestCheckFunc(
@@ -53,6 +55,7 @@ func TestAccSkytapVMCPURam_Create(t *testing.T) {
 				),
 			},
 			{
+				PreConfig: pause(),
 				Config: testAccSkytapVMConfig_basic(newEnvTemplateID, uniqueSuffixEnv, "", os.Getenv("SKYTAP_TEMPLATE_ID"), os.Getenv("SKYTAP_VM_ID"), "", "",
 					`"cpus" = 4
 									"ram" = 4096`),
@@ -66,6 +69,10 @@ func TestAccSkytapVMCPURam_Create(t *testing.T) {
 			},
 		},
 	})
+}
+
+func pause() func() {
+	return func() { time.Sleep(time.Duration(2) * time.Minute) }
 }
 
 func TestAccSkytapVMCPU_DiskIntact(t *testing.T) {
@@ -102,6 +109,7 @@ func TestAccSkytapVMCPU_DiskIntact(t *testing.T) {
 				),
 			},
 			{
+				PreConfig: pause(),
 				Config: testAccSkytapVMConfig_basic(newEnvTemplateID, uniqueSuffixEnv, "", os.Getenv("SKYTAP_TEMPLATE_ID"), os.Getenv("SKYTAP_VM_ID"), "", "",
 					`"cpus" = 4
 									"disk" = {
@@ -155,6 +163,7 @@ func TestAccSkytapVMCPU_WithDisk(t *testing.T) {
 				),
 			},
 			{
+				PreConfig: pause(),
 				Config: testAccSkytapVMConfig_basic(newEnvTemplateID, uniqueSuffixEnv, "", os.Getenv("SKYTAP_TEMPLATE_ID"), os.Getenv("SKYTAP_VM_ID"), "", "",
 					`"cpus" = 4
 									"disk" = {
@@ -202,6 +211,7 @@ func TestAccSkytapVMCPURAM_UpdateNPECheck(t *testing.T) {
 				),
 			},
 			{
+				PreConfig: pause(),
 				Config: testAccSkytapVMConfig_basic(newEnvTemplateID, uniqueSuffixEnv, "", os.Getenv("SKYTAP_TEMPLATE_ID"), os.Getenv("SKYTAP_VM_ID"), "", "",
 					`"cpus" = 8
 									"ram" = 2048`),
@@ -338,6 +348,7 @@ func TestAccSkytapVMDisks_Create(t *testing.T) {
 				),
 			},
 			{
+				PreConfig: pause(),
 				Config: testAccSkytapVMConfig_basic(newEnvTemplateID, uniqueSuffixEnv, "", os.Getenv("SKYTAP_TEMPLATE_ID"), os.Getenv("SKYTAP_VM_ID"), "", "",
 					`"disk" = {
 										"size" = 2048
@@ -386,6 +397,7 @@ func TestAccSkytapVMDisks_UpdateNPECheck(t *testing.T) {
 				),
 			},
 			{
+				PreConfig: pause(),
 				Config: testAccSkytapVMConfig_basic(newEnvTemplateID, uniqueSuffixEnv, "", os.Getenv("SKYTAP_TEMPLATE_ID"), os.Getenv("SKYTAP_VM_ID"), "", "",
 					`"disk" = {
 										"size" = 8000
@@ -434,6 +446,7 @@ func TestAccSkytapVMDisks_Resize(t *testing.T) {
 				),
 			},
 			{
+				PreConfig: pause(),
 				Config: testAccSkytapVMConfig_basic(newEnvTemplateID, uniqueSuffixEnv, "", os.Getenv("SKYTAP_TEMPLATE_ID"), os.Getenv("SKYTAP_VM_ID"), "", "",
 					`"disk" = {
 										"size" = 8192
@@ -526,6 +539,7 @@ func TestAccSkytapVMDisk_OS(t *testing.T) {
 				),
 			},
 			{
+				PreConfig: pause(),
 				Config: testAccSkytapVMConfig_basic(newEnvTemplateID, uniqueSuffixEnv, "", os.Getenv("SKYTAP_TEMPLATE_ID"), os.Getenv("SKYTAP_VM_ID"), "", "",
 					`"os_disk_size" = 30722`),
 				Check: resource.ComposeTestCheckFunc(
@@ -572,6 +586,7 @@ func TestAccSkytapVMDisk_OSChangeAfter(t *testing.T) {
 				),
 			},
 			{
+				PreConfig: pause(),
 				Config: testAccSkytapVMConfig_basic(newEnvTemplateID, uniqueSuffixEnv, "", os.Getenv("SKYTAP_TEMPLATE_ID"), os.Getenv("SKYTAP_VM_ID"), "", "",
 					`"os_disk_size" = 30721`),
 				Check: resource.ComposeTestCheckFunc(

--- a/skytap/resource_skytap_vm_hardware_test.go
+++ b/skytap/resource_skytap_vm_hardware_test.go
@@ -88,7 +88,7 @@ func TestAccSkytapVMCPU_DiskIntact(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSkytapVMExists("skytap_environment.foo", "skytap_vm.bar", &vm),
 					resource.TestCheckResourceAttr("skytap_vm.bar", "cpus", "8"),
-					testAccCheckSkytapVMDiskResource(t, "skytap_vm.bar", "1", []string{"smaller"}),
+					testAccCheckSkytapVMDiskResource(t, "skytap_vm.bar", "1", []string{"disk1"}),
 					testAccCheckSkytapVMCPU(t, &vm, 8),
 					testAccCheckSkytapVMDisks(t, &vm, []int{2048}),
 				),

--- a/skytap/resource_skytap_vm_hardware_test.go
+++ b/skytap/resource_skytap_vm_hardware_test.go
@@ -64,10 +64,6 @@ func TestAccSkytapVMCPURam_Create(t *testing.T) {
 	})
 }
 
-func pause() func() {
-	return func() { time.Sleep(time.Duration(2) * time.Minute) }
-}
-
 func TestAccSkytapVMCPU_DiskIntact(t *testing.T) {
 	//t.Parallel()
 
@@ -518,6 +514,10 @@ func TestAccSkytapVMDisk_OSChangeAfter(t *testing.T) {
 			},
 		},
 	})
+}
+
+func pause() func() {
+	return func() { time.Sleep(time.Duration(2) * time.Minute) }
 }
 
 func testAccCheckSkytapVMCPU(t *testing.T, vm *skytap.VM, cpus int) resource.TestCheckFunc {

--- a/skytap/resource_skytap_vm_test.go
+++ b/skytap/resource_skytap_vm_test.go
@@ -58,20 +58,12 @@ func testSweepSkytapVM(region string) error {
 func TestAccSkytapVM_Basic(t *testing.T) {
 	//t.Parallel()
 
-	if os.Getenv("SKYTAP_TEMPLATE_ID") == "" {
-		log.Printf("[WARN] SKYTAP_TEMPLATE_ID required to run skytap_vm_resource acceptance tests. Setting: SKYTAP_TEMPLATE_ID=1473407")
-		err := os.Setenv("SKYTAP_TEMPLATE_ID", "1473407")
-		assert.NoError(t, err)
+	templateSet, vmSet, newEnvTemplateID := setupEnvironment(t, "1473407", "37865463")
+	if templateSet {
+		defer unsetEnv("SKYTAP_TEMPLATE_ID")
 	}
-	if os.Getenv("SKYTAP_VM_ID") == "" {
-		log.Printf("[WARN] SKYTAP_VM_ID required to run skytap_vm_resource acceptance tests. Setting: SKYTAP_VM_ID=37865463")
-		err := os.Setenv("SKYTAP_VM_ID", "37865463")
-		assert.NoError(t, err)
-	}
-	newEnvTemplateID := os.Getenv("SKYTAP_TEMPLATE_ID")
-	if os.Getenv("SKYTAP_TEMPLATE_NEW_ENV_ID") != "" {
-		newEnvTemplateID = os.Getenv("SKYTAP_TEMPLATE_NEW_ENV_ID")
-		log.Printf("[DEBUG] SKYTAP_TEMPLATE_NEW_ENV_ID=%s", newEnvTemplateID)
+	if vmSet {
+		defer unsetEnv("SKYTAP_VM_ID")
 	}
 	uniqueSuffixEnv := acctest.RandInt()
 	var vm skytap.VM
@@ -96,20 +88,12 @@ func TestAccSkytapVM_Basic(t *testing.T) {
 func TestAccSkytapVM_Update(t *testing.T) {
 	//t.Parallel()
 
-	if os.Getenv("SKYTAP_TEMPLATE_ID") == "" {
-		log.Printf("[WARN] SKYTAP_TEMPLATE_ID required to run skytap_vm_resource acceptance tests. Setting: SKYTAP_TEMPLATE_ID=1473407")
-		err := os.Setenv("SKYTAP_TEMPLATE_ID", "1473407")
-		assert.NoError(t, err)
+	templateSet, vmSet, newEnvTemplateID := setupEnvironment(t, "1473407", "37865463")
+	if templateSet {
+		defer unsetEnv("SKYTAP_TEMPLATE_ID")
 	}
-	if os.Getenv("SKYTAP_VM_ID") == "" {
-		log.Printf("[WARN] SKYTAP_VM_ID required to run skytap_vm_resource acceptance tests. Setting: SKYTAP_VM_ID=37865463")
-		err := os.Setenv("SKYTAP_VM_ID", "37865463")
-		assert.NoError(t, err)
-	}
-	newEnvTemplateID := os.Getenv("SKYTAP_TEMPLATE_ID")
-	if os.Getenv("SKYTAP_TEMPLATE_NEW_ENV_ID") != "" {
-		newEnvTemplateID = os.Getenv("SKYTAP_TEMPLATE_NEW_ENV_ID")
-		log.Printf("[DEBUG] SKYTAP_TEMPLATE_NEW_ENV_ID=%s", newEnvTemplateID)
+	if vmSet {
+		defer unsetEnv("SKYTAP_VM_ID")
 	}
 	uniqueSuffixEnv := acctest.RandInt()
 	uniqueSuffixVM := acctest.RandInt()
@@ -143,20 +127,12 @@ func TestAccSkytapVM_Update(t *testing.T) {
 func TestAccSkytapVM_Interface(t *testing.T) {
 	//t.Parallel()
 
-	if os.Getenv("SKYTAP_TEMPLATE_ID") == "" {
-		log.Printf("[WARN] SKYTAP_TEMPLATE_ID required to run skytap_vm_resource acceptance tests. Setting: SKYTAP_TEMPLATE_ID=1473407")
-		err := os.Setenv("SKYTAP_TEMPLATE_ID", "1473407")
-		assert.NoError(t, err)
+	templateSet, vmSet, newEnvTemplateID := setupEnvironment(t, "1473407", "37865463")
+	if templateSet {
+		defer unsetEnv("SKYTAP_TEMPLATE_ID")
 	}
-	if os.Getenv("SKYTAP_VM_ID") == "" {
-		log.Printf("[WARN] SKYTAP_VM_ID required to run skytap_vm_resource acceptance tests. Setting: SKYTAP_VM_ID=37865463")
-		err := os.Setenv("SKYTAP_VM_ID", "37865463")
-		assert.NoError(t, err)
-	}
-	newEnvTemplateID := os.Getenv("SKYTAP_TEMPLATE_ID")
-	if os.Getenv("SKYTAP_TEMPLATE_NEW_ENV_ID") != "" {
-		newEnvTemplateID = os.Getenv("SKYTAP_TEMPLATE_NEW_ENV_ID")
-		log.Printf("[DEBUG] SKYTAP_TEMPLATE_NEW_ENV_ID=%s", newEnvTemplateID)
+	if vmSet {
+		defer unsetEnv("SKYTAP_VM_ID")
 	}
 	uniqueSuffixEnv := acctest.RandInt()
 	var vm skytap.VM
@@ -240,20 +216,12 @@ func TestAccSkytapVM_Interface(t *testing.T) {
 func TestAccSkytapVM_PublishedService(t *testing.T) {
 	//t.Parallel()
 
-	if os.Getenv("SKYTAP_TEMPLATE_ID") == "" {
-		log.Printf("[WARN] SKYTAP_TEMPLATE_ID required to run skytap_vm_resource acceptance tests. Setting: SKYTAP_TEMPLATE_ID=136409")
-		err := os.Setenv("SKYTAP_TEMPLATE_ID", "136409")
-		assert.NoError(t, err)
+	templateSet, vmSet, newEnvTemplateID := setupEnvironment(t, "136409", "849656")
+	if templateSet {
+		defer unsetEnv("SKYTAP_TEMPLATE_ID")
 	}
-	if os.Getenv("SKYTAP_VM_ID") == "" {
-		log.Printf("[WARN] SKYTAP_VM_ID required to run skytap_vm_resource acceptance tests. Setting: SKYTAP_VM_ID=849656")
-		err := os.Setenv("SKYTAP_VM_ID", "849656")
-		assert.NoError(t, err)
-	}
-	newEnvTemplateID := os.Getenv("SKYTAP_TEMPLATE_ID")
-	if os.Getenv("SKYTAP_TEMPLATE_NEW_ENV_ID") != "" {
-		newEnvTemplateID = os.Getenv("SKYTAP_TEMPLATE_NEW_ENV_ID")
-		log.Printf("[DEBUG] SKYTAP_TEMPLATE_NEW_ENV_ID=%s", newEnvTemplateID)
+	if vmSet {
+		defer unsetEnv("SKYTAP_VM_ID")
 	}
 	uniqueSuffixEnv := acctest.RandInt()
 	var vm skytap.VM
@@ -368,20 +336,12 @@ func TestAccSkytapVM_PublishedService(t *testing.T) {
 func TestAccSkytapVM_PublishedServiceBadNic(t *testing.T) {
 	//t.Parallel()
 
-	if os.Getenv("SKYTAP_TEMPLATE_ID") == "" {
-		log.Printf("[WARN] SKYTAP_TEMPLATE_ID required to run skytap_vm_resource acceptance tests. Setting: SKYTAP_TEMPLATE_ID=1473407")
-		err := os.Setenv("SKYTAP_TEMPLATE_ID", "1473407")
-		assert.NoError(t, err)
+	templateSet, vmSet, newEnvTemplateID := setupEnvironment(t, "1473407", "37865463")
+	if templateSet {
+		defer unsetEnv("SKYTAP_TEMPLATE_ID")
 	}
-	if os.Getenv("SKYTAP_VM_ID") == "" {
-		log.Printf("[WARN] SKYTAP_VM_ID required to run skytap_vm_resource acceptance tests. Setting: SKYTAP_VM_ID=37865463")
-		err := os.Setenv("SKYTAP_VM_ID", "37865463")
-		assert.NoError(t, err)
-	}
-	newEnvTemplateID := os.Getenv("SKYTAP_TEMPLATE_ID")
-	if os.Getenv("SKYTAP_TEMPLATE_NEW_ENV_ID") != "" {
-		newEnvTemplateID = os.Getenv("SKYTAP_TEMPLATE_NEW_ENV_ID")
-		log.Printf("[DEBUG] SKYTAP_TEMPLATE_NEW_ENV_ID=%s", newEnvTemplateID)
+	if vmSet {
+		defer unsetEnv("SKYTAP_VM_ID")
 	}
 	uniqueSuffixEnv := acctest.RandInt()
 
@@ -411,20 +371,12 @@ func TestAccSkytapVM_PublishedServiceBadNic(t *testing.T) {
 
 func TestAccExternalPorts(t *testing.T) {
 
-	if os.Getenv("SKYTAP_TEMPLATE_ID") == "" {
-		log.Printf("[WARN] SKYTAP_TEMPLATE_ID required to run skytap_vm_resource acceptance tests. Setting: SKYTAP_TEMPLATE_ID=1473407")
-		err := os.Setenv("SKYTAP_TEMPLATE_ID", "1473407")
-		assert.NoError(t, err)
+	templateSet, vmSet, newEnvTemplateID := setupEnvironment(t, "1473407", "37865463")
+	if templateSet {
+		defer unsetEnv("SKYTAP_TEMPLATE_ID")
 	}
-	if os.Getenv("SKYTAP_VM_ID") == "" {
-		log.Printf("[WARN] SKYTAP_VM_ID required to run skytap_vm_resource acceptance tests. Setting: SKYTAP_VM_ID=37865463")
-		err := os.Setenv("SKYTAP_VM_ID", "37865463")
-		assert.NoError(t, err)
-	}
-	newEnvTemplateID := os.Getenv("SKYTAP_TEMPLATE_ID")
-	if os.Getenv("SKYTAP_TEMPLATE_NEW_ENV_ID") != "" {
-		newEnvTemplateID = os.Getenv("SKYTAP_TEMPLATE_NEW_ENV_ID")
-		log.Printf("[DEBUG] SKYTAP_TEMPLATE_NEW_ENV_ID=%s", newEnvTemplateID)
+	if vmSet {
+		defer unsetEnv("SKYTAP_VM_ID")
 	}
 
 	uniqueSuffixEnv := acctest.RandInt()
@@ -475,20 +427,12 @@ func testAccCheckSkytapExternalPorts(t *testing.T, vmName string, count string) 
 
 func TestAccCasandra(t *testing.T) {
 
-	if os.Getenv("SKYTAP_TEMPLATE_ID") == "" {
-		log.Printf("[WARN] SKYTAP_TEMPLATE_ID required to run skytap_vm_resource acceptance tests. Setting: SKYTAP_TEMPLATE_ID=1473407")
-		err := os.Setenv("SKYTAP_TEMPLATE_ID", "1473407")
-		assert.NoError(t, err)
+	templateSet, vmSet, newEnvTemplateID := setupEnvironment(t, "1473407", "37865463")
+	if templateSet {
+		defer unsetEnv("SKYTAP_TEMPLATE_ID")
 	}
-	if os.Getenv("SKYTAP_VM_ID") == "" {
-		log.Printf("[WARN] SKYTAP_VM_ID required to run skytap_vm_resource acceptance tests. Setting: SKYTAP_VM_ID=37865463")
-		err := os.Setenv("SKYTAP_VM_ID", "37865463")
-		assert.NoError(t, err)
-	}
-	newEnvTemplateID := os.Getenv("SKYTAP_TEMPLATE_ID")
-	if os.Getenv("SKYTAP_TEMPLATE_NEW_ENV_ID") != "" {
-		newEnvTemplateID = os.Getenv("SKYTAP_TEMPLATE_NEW_ENV_ID")
-		log.Printf("[DEBUG] SKYTAP_TEMPLATE_NEW_ENV_ID=%s", newEnvTemplateID)
+	if vmSet {
+		defer unsetEnv("SKYTAP_VM_ID")
 	}
 	uniqueSuffixEnv := acctest.RandInt()
 
@@ -525,6 +469,34 @@ func TestAccCasandra(t *testing.T) {
 			},
 		},
 	})
+}
+
+func setupEnvironment(t *testing.T, templateID string, vmID string) (bool, bool, string) {
+	templateSet := setEnv(t, "SKYTAP_TEMPLATE_ID", templateID)
+	vmSet := setEnv(t, "SKYTAP_VM_ID", vmID)
+	newEnvTemplateID := os.Getenv("SKYTAP_TEMPLATE_ID")
+	if os.Getenv("SKYTAP_TEMPLATE_NEW_ENV_ID") != "" {
+		newEnvTemplateID = os.Getenv("SKYTAP_TEMPLATE_NEW_ENV_ID")
+		log.Printf("[DEBUG] SKYTAP_TEMPLATE_NEW_ENV_ID=%s", newEnvTemplateID)
+	}
+	return templateSet, vmSet, newEnvTemplateID
+}
+
+func setEnv(t *testing.T, key string, value string) bool {
+	if os.Getenv(key) == "" {
+		log.Printf("[WARN] variable required to run skytap_vm_resource acceptance tests. Setting: %s=%s", key, value)
+		err := os.Setenv(key, value)
+		assert.NoError(t, err)
+		return true
+	}
+	return false
+}
+
+func unsetEnv(variable string) {
+	err := os.Unsetenv(variable)
+	if err != nil {
+		log.Printf("[ERROR] could not unset environment variable (%s)", variable)
+	}
 }
 
 func testAccSkytapVMConfig_cassandra(envTemplateID string, templateID string, vmID string, uniqueSuffixEnv int, existingPort int, extraPublishedService string, extraNIC string) string {

--- a/skytap/resource_skytap_vm_test.go
+++ b/skytap/resource_skytap_vm_test.go
@@ -355,7 +355,7 @@ func TestAccExternalPorts(t *testing.T) {
 		CheckDestroy: testAccCheckSkytapEnvironmentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSkytapVMConfig_cassandra(newEnvTemplateID, templateID, vmID, uniqueSuffixEnv, 23,
+				Config: testAccSkytapVMConfig_typical(newEnvTemplateID, templateID, vmID, uniqueSuffixEnv, 23,
 					`"published_service" = {"name" = "web-internal" "internal_port" = 8080}`,
 					`"network_interface" = {
     	              "interface_type" = "vmxnet3"
@@ -380,7 +380,7 @@ func TestAccExternalPorts(t *testing.T) {
 	})
 }
 
-func TestAccCasandra(t *testing.T) {
+func TestAccSkytapVM_Typical(t *testing.T) {
 
 	templateID, vmID, newEnvTemplateID := setupEnvironment("1473407", "37865463")
 	uniqueSuffixEnv := acctest.RandInt()
@@ -391,11 +391,11 @@ func TestAccCasandra(t *testing.T) {
 		CheckDestroy: testAccCheckSkytapEnvironmentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:             testAccSkytapVMConfig_cassandra(newEnvTemplateID, templateID, vmID, uniqueSuffixEnv, 22, "", ""),
+				Config:             testAccSkytapVMConfig_typical(newEnvTemplateID, templateID, vmID, uniqueSuffixEnv, 22, "", ""),
 				ExpectNonEmptyPlan: false,
 			}, {
 				PreConfig: pause(),
-				Config: testAccSkytapVMConfig_cassandra(newEnvTemplateID, templateID, vmID, uniqueSuffixEnv, 23,
+				Config: testAccSkytapVMConfig_typical(newEnvTemplateID, templateID, vmID, uniqueSuffixEnv, 23,
 					`"published_service" = {
 						name = "web-internal"
 						"internal_port" = 8080
@@ -435,9 +435,9 @@ func testAccCheckSkytapExternalPorts(t *testing.T, vmName string, count string) 
 }
 
 func setupEnvironmentWithKeys(templateKey string, templateIDFallback string, vmKey string, vmIDFallback string) (string, string, string) {
-	templateID := getEnv(templateKey, templateIDFallback)
-	vmID := getEnv(vmKey, vmIDFallback)
-	newEnvTemplateID := getEnv("SKYTAP_TEMPLATE_NEW_ENV_ID", templateID)
+	templateID := utils.GetEnv(templateKey, templateIDFallback)
+	vmID := utils.GetEnv(vmKey, vmIDFallback)
+	newEnvTemplateID := utils.GetEnv("SKYTAP_TEMPLATE_NEW_ENV_ID", templateID)
 	return templateID, vmID, newEnvTemplateID
 }
 
@@ -445,16 +445,7 @@ func setupEnvironment(templateIDFallback string, vmIDFallback string) (string, s
 	return setupEnvironmentWithKeys("SKYTAP_TEMPLATE_ID", templateIDFallback, "SKYTAP_VM_ID", vmIDFallback)
 }
 
-func getEnv(key, fallback string) string {
-	value := fallback
-	if v, ok := os.LookupEnv(key); ok {
-		value = v
-	}
-	log.Printf("[DEBUG] %s=%s", key, value)
-	return value
-}
-
-func testAccSkytapVMConfig_cassandra(envTemplateID string, templateID string, vmID string, uniqueSuffixEnv int, existingPort int, extraPublishedService string, extraNIC string) string {
+func testAccSkytapVMConfig_typical(envTemplateID string, templateID string, vmID string, uniqueSuffixEnv int, existingPort int, extraPublishedService string, extraNIC string) string {
 	config := fmt.Sprintf(`
 
     resource "skytap_environment" "my_new_environment" {

--- a/skytap/resource_skytap_vm_test.go
+++ b/skytap/resource_skytap_vm_test.go
@@ -58,7 +58,7 @@ func testSweepSkytapVM(region string) error {
 func TestAccSkytapVM_Basic(t *testing.T) {
 	//t.Parallel()
 
-	templateID, vmID, newEnvTemplateID := setupEnvironment("1473407", "37865463")
+	templateID, vmID, newEnvTemplateID := setupEnvironment()
 	uniqueSuffixEnv := acctest.RandInt()
 	var vm skytap.VM
 
@@ -82,7 +82,7 @@ func TestAccSkytapVM_Basic(t *testing.T) {
 func TestAccSkytapVM_Update(t *testing.T) {
 	//t.Parallel()
 
-	templateID, vmID, newEnvTemplateID := setupEnvironment("1473407", "37865463")
+	templateID, vmID, newEnvTemplateID := setupEnvironment()
 	uniqueSuffixEnv := acctest.RandInt()
 	uniqueSuffixVM := acctest.RandInt()
 	var vm skytap.VM
@@ -115,7 +115,7 @@ func TestAccSkytapVM_Update(t *testing.T) {
 func TestAccSkytapVM_Interface(t *testing.T) {
 	//t.Parallel()
 
-	templateID, vmID, newEnvTemplateID := setupEnvironment("1473407", "37865463")
+	templateID, vmID, newEnvTemplateID := setupEnvironment()
 	uniqueSuffixEnv := acctest.RandInt()
 	var vm skytap.VM
 
@@ -200,7 +200,7 @@ func TestAccSkytapVM_Interface(t *testing.T) {
 func TestAccSkytapVM_PublishedService(t *testing.T) {
 	//t.Parallel()
 
-	templateID, vmID, newEnvTemplateID := setupEnvironment("1473407", "37865463")
+	templateID, vmID, newEnvTemplateID := setupEnvironment()
 	uniqueSuffixEnv := acctest.RandInt()
 	var vm skytap.VM
 
@@ -317,7 +317,7 @@ func TestAccSkytapVM_PublishedService(t *testing.T) {
 func TestAccSkytapVM_PublishedServiceBadNic(t *testing.T) {
 	//t.Parallel()
 
-	templateID, vmID, newEnvTemplateID := setupEnvironment("1473407", "37865463")
+	templateID, vmID, newEnvTemplateID := setupEnvironment()
 	uniqueSuffixEnv := acctest.RandInt()
 
 	resource.Test(t, resource.TestCase{
@@ -346,7 +346,7 @@ func TestAccSkytapVM_PublishedServiceBadNic(t *testing.T) {
 
 func TestAccExternalPorts(t *testing.T) {
 
-	templateID, vmID, newEnvTemplateID := setupEnvironment("1473407", "37865463")
+	templateID, vmID, newEnvTemplateID := setupEnvironment()
 	uniqueSuffixEnv := acctest.RandInt()
 
 	resource.Test(t, resource.TestCase{
@@ -382,7 +382,7 @@ func TestAccExternalPorts(t *testing.T) {
 
 func TestAccSkytapVM_Typical(t *testing.T) {
 
-	templateID, vmID, newEnvTemplateID := setupEnvironment("1473407", "37865463")
+	templateID, vmID, newEnvTemplateID := setupEnvironment()
 	uniqueSuffixEnv := acctest.RandInt()
 
 	resource.Test(t, resource.TestCase{
@@ -434,15 +434,15 @@ func testAccCheckSkytapExternalPorts(t *testing.T, vmName string, count string) 
 	}
 }
 
-func setupEnvironmentWithKeys(templateKey string, templateIDFallback string, vmKey string, vmIDFallback string) (string, string, string) {
-	templateID := utils.GetEnv(templateKey, templateIDFallback)
-	vmID := utils.GetEnv(vmKey, vmIDFallback)
-	newEnvTemplateID := utils.GetEnv("SKYTAP_TEMPLATE_NEW_ENV_ID", templateID)
-	return templateID, vmID, newEnvTemplateID
+func setupNonDefaultEnvironment(templateKey string, templateIDFallback string, vmKey string, vmIDFallback string) (templateID, vmID, newEnvTemplateID string) {
+	templateID = utils.GetEnv(templateKey, templateIDFallback)
+	vmID = utils.GetEnv(vmKey, vmIDFallback)
+	newEnvTemplateID = utils.GetEnv("SKYTAP_TEMPLATE_NEW_ENV_ID", templateID)
+	return
 }
 
-func setupEnvironment(templateIDFallback string, vmIDFallback string) (string, string, string) {
-	return setupEnvironmentWithKeys("SKYTAP_TEMPLATE_ID", templateIDFallback, "SKYTAP_VM_ID", vmIDFallback)
+func setupEnvironment() (string, string, string) {
+	return setupNonDefaultEnvironment("SKYTAP_TEMPLATE_ID", "1473407", "SKYTAP_VM_ID", "37865463")
 }
 
 func testAccSkytapVMConfig_typical(envTemplateID string, templateID string, vmID string, uniqueSuffixEnv int, existingPort int, extraPublishedService string, extraNIC string) string {

--- a/skytap/resource_skytap_vm_test.go
+++ b/skytap/resource_skytap_vm_test.go
@@ -380,19 +380,6 @@ func TestAccExternalPorts(t *testing.T) {
 	})
 }
 
-func testAccCheckSkytapExternalPorts(t *testing.T, vmName string, count string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rsVM, err := getResource(s, vmName)
-		if err != nil {
-			return err
-		}
-		assert.Equal(t, count, rsVM.Primary.Attributes["service_ports.%"], "empty map entry")
-		assert.Equal(t, count, rsVM.Primary.Attributes["service_ips.%"], "empty map entry")
-
-		return nil
-	}
-}
-
 func TestAccCasandra(t *testing.T) {
 
 	templateID, vmID, newEnvTemplateID := setupEnvironment("1473407", "37865463")
@@ -432,6 +419,19 @@ func TestAccCasandra(t *testing.T) {
 			},
 		},
 	})
+}
+
+func testAccCheckSkytapExternalPorts(t *testing.T, vmName string, count string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rsVM, err := getResource(s, vmName)
+		if err != nil {
+			return err
+		}
+		assert.Equal(t, count, rsVM.Primary.Attributes["service_ports.%"], "empty map entry")
+		assert.Equal(t, count, rsVM.Primary.Attributes["service_ips.%"], "empty map entry")
+
+		return nil
+	}
 }
 
 func setupEnvironmentWithKeys(templateKey string, templateIDFallback string, vmKey string, vmIDFallback string) (string, string, string) {

--- a/skytap/resource_skytap_vm_test.go
+++ b/skytap/resource_skytap_vm_test.go
@@ -58,13 +58,7 @@ func testSweepSkytapVM(region string) error {
 func TestAccSkytapVM_Basic(t *testing.T) {
 	//t.Parallel()
 
-	templateSet, vmSet, newEnvTemplateID := setupEnvironment(t, "1473407", "37865463")
-	if templateSet {
-		defer unsetEnv("SKYTAP_TEMPLATE_ID")
-	}
-	if vmSet {
-		defer unsetEnv("SKYTAP_VM_ID")
-	}
+	templateID, vmID, newEnvTemplateID := setupEnvironment("1473407", "37865463")
 	uniqueSuffixEnv := acctest.RandInt()
 	var vm skytap.VM
 
@@ -74,7 +68,7 @@ func TestAccSkytapVM_Basic(t *testing.T) {
 		CheckDestroy: testAccCheckSkytapEnvironmentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSkytapVMConfig_basic(newEnvTemplateID, uniqueSuffixEnv, "", os.Getenv("SKYTAP_TEMPLATE_ID"), os.Getenv("SKYTAP_VM_ID"), "name = \"test\"", "", ``),
+				Config: testAccSkytapVMConfig_basic(newEnvTemplateID, uniqueSuffixEnv, "", templateID, vmID, "name = \"test\"", "", ``),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSkytapVMExists("skytap_environment.foo", "skytap_vm.bar", &vm),
 					resource.TestCheckResourceAttr("skytap_vm.bar", "name", "test"),
@@ -88,13 +82,7 @@ func TestAccSkytapVM_Basic(t *testing.T) {
 func TestAccSkytapVM_Update(t *testing.T) {
 	//t.Parallel()
 
-	templateSet, vmSet, newEnvTemplateID := setupEnvironment(t, "1473407", "37865463")
-	if templateSet {
-		defer unsetEnv("SKYTAP_TEMPLATE_ID")
-	}
-	if vmSet {
-		defer unsetEnv("SKYTAP_VM_ID")
-	}
+	templateID, vmID, newEnvTemplateID := setupEnvironment("1473407", "37865463")
 	uniqueSuffixEnv := acctest.RandInt()
 	uniqueSuffixVM := acctest.RandInt()
 	var vm skytap.VM
@@ -105,7 +93,7 @@ func TestAccSkytapVM_Update(t *testing.T) {
 		CheckDestroy: testAccCheckSkytapEnvironmentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSkytapVMConfig_basic(newEnvTemplateID, uniqueSuffixEnv, "", os.Getenv("SKYTAP_TEMPLATE_ID"), os.Getenv("SKYTAP_VM_ID"), "", "", ``),
+				Config: testAccSkytapVMConfig_basic(newEnvTemplateID, uniqueSuffixEnv, "", templateID, vmID, "", "", ``),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSkytapVMExists("skytap_environment.foo", "skytap_vm.bar", &vm),
 					resource.TestCheckResourceAttrSet("skytap_vm.bar", "name"),
@@ -113,7 +101,7 @@ func TestAccSkytapVM_Update(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccSkytapVMConfig_basic(newEnvTemplateID, uniqueSuffixEnv, "", os.Getenv("SKYTAP_TEMPLATE_ID"), os.Getenv("SKYTAP_VM_ID"),
+				Config: testAccSkytapVMConfig_basic(newEnvTemplateID, uniqueSuffixEnv, "", templateID, vmID,
 					fmt.Sprintf("name = \"tftest-vm-%d\"", uniqueSuffixVM), "", ``),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("skytap_vm.bar", "name", fmt.Sprintf("tftest-vm-%d", uniqueSuffixVM)),
@@ -127,13 +115,7 @@ func TestAccSkytapVM_Update(t *testing.T) {
 func TestAccSkytapVM_Interface(t *testing.T) {
 	//t.Parallel()
 
-	templateSet, vmSet, newEnvTemplateID := setupEnvironment(t, "1473407", "37865463")
-	if templateSet {
-		defer unsetEnv("SKYTAP_TEMPLATE_ID")
-	}
-	if vmSet {
-		defer unsetEnv("SKYTAP_VM_ID")
-	}
+	templateID, vmID, newEnvTemplateID := setupEnvironment("1473407", "37865463")
 	uniqueSuffixEnv := acctest.RandInt()
 	var vm skytap.VM
 
@@ -148,7 +130,7 @@ func TestAccSkytapVM_Interface(t *testing.T) {
   						"name"        		= "tftest-network-1"
 						"domain"      		= "mydomain.com"
   						"environment_id" 	= "${skytap_environment.foo.id}"
-  						"subnet"      		= "192.168.0.0/16"}`, os.Getenv("SKYTAP_TEMPLATE_ID"), os.Getenv("SKYTAP_VM_ID"), "name = \"test\"", `
+  						"subnet"      		= "192.168.0.0/16"}`, templateID, vmID, "name = \"test\"", `
                   	network_interface {
                     	interface_type = "vmxnet3"
                     	network_id = "${skytap_network.baz.id}"
@@ -173,7 +155,7 @@ func TestAccSkytapVM_Interface(t *testing.T) {
   						"name"        		= "tftest-network-1"
 						"domain"      		= "mydomain.com"
   						"environment_id" 	= "${skytap_environment.foo.id}"
-  						"subnet"      		= "192.168.0.0/16"}`, os.Getenv("SKYTAP_TEMPLATE_ID"), os.Getenv("SKYTAP_VM_ID"), "name = \"test\"", `
+  						"subnet"      		= "192.168.0.0/16"}`, templateID, vmID, "name = \"test\"", `
                  	network_interface {
                    		interface_type = "vmxnet3"
                    		network_id = "${skytap_network.baz.id}"
@@ -198,7 +180,7 @@ func TestAccSkytapVM_Interface(t *testing.T) {
   						"name"        		= "tftest-network-1"
 						"domain"      		= "mydomain.com"
   						"environment_id" 	= "${skytap_environment.foo.id}"
-  						"subnet"      		= "192.168.0.0/16"}`, os.Getenv("SKYTAP_TEMPLATE_ID"), os.Getenv("SKYTAP_VM_ID"), "name = \"test\"", `
+  						"subnet"      		= "192.168.0.0/16"}`, templateID, vmID, "name = \"test\"", `
                  	network_interface {
                    	interface_type = "vmxnet3"
                    		network_id = "${skytap_network.baz.id}"
@@ -218,13 +200,7 @@ func TestAccSkytapVM_Interface(t *testing.T) {
 func TestAccSkytapVM_PublishedService(t *testing.T) {
 	//t.Parallel()
 
-	templateSet, vmSet, newEnvTemplateID := setupEnvironment(t, "136409", "849656")
-	if templateSet {
-		defer unsetEnv("SKYTAP_TEMPLATE_ID")
-	}
-	if vmSet {
-		defer unsetEnv("SKYTAP_VM_ID")
-	}
+	templateID, vmID, newEnvTemplateID := setupEnvironment("1473407", "37865463")
 	uniqueSuffixEnv := acctest.RandInt()
 	var vm skytap.VM
 
@@ -239,7 +215,7 @@ func TestAccSkytapVM_PublishedService(t *testing.T) {
   						"name"        		= "tftest-network-1"
 						"domain"      		= "mydomain.com"
   						"environment_id" 	= "${skytap_environment.foo.id}"
-  						"subnet"      		= "192.168.0.0/16"}`, os.Getenv("SKYTAP_TEMPLATE_ID"), os.Getenv("SKYTAP_VM_ID"), "name = \"test\"", `
+  						"subnet"      		= "192.168.0.0/16"}`, templateID, vmID, "name = \"test\"", `
                   	network_interface {
                     	interface_type = "vmxnet3"
                     	network_id = "${skytap_network.baz.id}"
@@ -266,7 +242,7 @@ func TestAccSkytapVM_PublishedService(t *testing.T) {
   						"name"        		= "tftest-network-1"
 						"domain"      		= "mydomain.com"
   						"environment_id" 	= "${skytap_environment.foo.id}"
-  						"subnet"      		= "192.168.0.0/16"}`, os.Getenv("SKYTAP_TEMPLATE_ID"), os.Getenv("SKYTAP_VM_ID"), "name = \"test\"", `
+  						"subnet"      		= "192.168.0.0/16"}`, templateID, vmID, "name = \"test\"", `
                   	network_interface {
                     	interface_type = "vmxnet3"
                     	network_id = "${skytap_network.baz.id}"
@@ -293,7 +269,7 @@ func TestAccSkytapVM_PublishedService(t *testing.T) {
   						"name"        		= "tftest-network-1"
 						"domain"      		= "mydomain.com"
   						"environment_id" 	= "${skytap_environment.foo.id}"
-  						"subnet"      		= "192.168.0.0/16"}`, os.Getenv("SKYTAP_TEMPLATE_ID"), os.Getenv("SKYTAP_VM_ID"), "name = \"test\"", `
+  						"subnet"      		= "192.168.0.0/16"}`, templateID, vmID, "name = \"test\"", `
                   	network_interface {
                     	interface_type = "vmxnet3"
                     	network_id = "${skytap_network.baz.id}"
@@ -316,7 +292,7 @@ func TestAccSkytapVM_PublishedService(t *testing.T) {
   						"name"        		= "tftest-network-1"
 						"domain"      		= "mydomain.com"
   						"environment_id" 	= "${skytap_environment.foo.id}"
-  						"subnet"      		= "192.168.0.0/16"}`, os.Getenv("SKYTAP_TEMPLATE_ID"), os.Getenv("SKYTAP_VM_ID"), "name = \"test\"", `
+  						"subnet"      		= "192.168.0.0/16"}`, templateID, vmID, "name = \"test\"", `
                   	network_interface {
                     	interface_type = "e1000"
                     	network_id = "${skytap_network.baz.id}"
@@ -341,13 +317,7 @@ func TestAccSkytapVM_PublishedService(t *testing.T) {
 func TestAccSkytapVM_PublishedServiceBadNic(t *testing.T) {
 	//t.Parallel()
 
-	templateSet, vmSet, newEnvTemplateID := setupEnvironment(t, "1473407", "37865463")
-	if templateSet {
-		defer unsetEnv("SKYTAP_TEMPLATE_ID")
-	}
-	if vmSet {
-		defer unsetEnv("SKYTAP_VM_ID")
-	}
+	templateID, vmID, newEnvTemplateID := setupEnvironment("1473407", "37865463")
 	uniqueSuffixEnv := acctest.RandInt()
 
 	resource.Test(t, resource.TestCase{
@@ -361,7 +331,7 @@ func TestAccSkytapVM_PublishedServiceBadNic(t *testing.T) {
   						"name"        		= "tftest-network-1"
 						"domain"      		= "mydomain.com"
   						"environment_id" 	= "${skytap_environment.foo.id}"
-  						"subnet"      		= "192.168.0.0/16"}`, os.Getenv("SKYTAP_TEMPLATE_ID"), os.Getenv("SKYTAP_VM_ID"), "name = \"test\"", `
+  						"subnet"      		= "192.168.0.0/16"}`, templateID, vmID, "name = \"test\"", `
                   	network_interface {
                     	interface_type = "e1000e"
                     	network_id = "${skytap_network.baz.id}"
@@ -376,14 +346,7 @@ func TestAccSkytapVM_PublishedServiceBadNic(t *testing.T) {
 
 func TestAccExternalPorts(t *testing.T) {
 
-	templateSet, vmSet, newEnvTemplateID := setupEnvironment(t, "1473407", "37865463")
-	if templateSet {
-		defer unsetEnv("SKYTAP_TEMPLATE_ID")
-	}
-	if vmSet {
-		defer unsetEnv("SKYTAP_VM_ID")
-	}
-
+	templateID, vmID, newEnvTemplateID := setupEnvironment("1473407", "37865463")
 	uniqueSuffixEnv := acctest.RandInt()
 
 	resource.Test(t, resource.TestCase{
@@ -392,7 +355,7 @@ func TestAccExternalPorts(t *testing.T) {
 		CheckDestroy: testAccCheckSkytapEnvironmentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSkytapVMConfig_cassandra(newEnvTemplateID, os.Getenv("SKYTAP_TEMPLATE_ID"), os.Getenv("SKYTAP_VM_ID"), uniqueSuffixEnv, 23,
+				Config: testAccSkytapVMConfig_cassandra(newEnvTemplateID, templateID, vmID, uniqueSuffixEnv, 23,
 					`"published_service" = {"name" = "web-internal" "internal_port" = 8080}`,
 					`"network_interface" = {
     	              "interface_type" = "vmxnet3"
@@ -432,13 +395,7 @@ func testAccCheckSkytapExternalPorts(t *testing.T, vmName string, count string) 
 
 func TestAccCasandra(t *testing.T) {
 
-	templateSet, vmSet, newEnvTemplateID := setupEnvironment(t, "1473407", "37865463")
-	if templateSet {
-		defer unsetEnv("SKYTAP_TEMPLATE_ID")
-	}
-	if vmSet {
-		defer unsetEnv("SKYTAP_VM_ID")
-	}
+	templateID, vmID, newEnvTemplateID := setupEnvironment("1473407", "37865463")
 	uniqueSuffixEnv := acctest.RandInt()
 
 	resource.Test(t, resource.TestCase{
@@ -447,11 +404,11 @@ func TestAccCasandra(t *testing.T) {
 		CheckDestroy: testAccCheckSkytapEnvironmentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:             testAccSkytapVMConfig_cassandra(newEnvTemplateID, os.Getenv("SKYTAP_TEMPLATE_ID"), os.Getenv("SKYTAP_VM_ID"), uniqueSuffixEnv, 22, "", ""),
+				Config:             testAccSkytapVMConfig_cassandra(newEnvTemplateID, templateID, vmID, uniqueSuffixEnv, 22, "", ""),
 				ExpectNonEmptyPlan: false,
 			}, {
 				PreConfig: pause(),
-				Config: testAccSkytapVMConfig_cassandra(newEnvTemplateID, os.Getenv("SKYTAP_TEMPLATE_ID"), os.Getenv("SKYTAP_VM_ID"), uniqueSuffixEnv, 23,
+				Config: testAccSkytapVMConfig_cassandra(newEnvTemplateID, templateID, vmID, uniqueSuffixEnv, 23,
 					`"published_service" = {
 						name = "web-internal"
 						"internal_port" = 8080
@@ -477,32 +434,24 @@ func TestAccCasandra(t *testing.T) {
 	})
 }
 
-func setupEnvironment(t *testing.T, templateID string, vmID string) (bool, bool, string) {
-	templateSet := setEnv(t, "SKYTAP_TEMPLATE_ID", templateID)
-	vmSet := setEnv(t, "SKYTAP_VM_ID", vmID)
-	newEnvTemplateID := os.Getenv("SKYTAP_TEMPLATE_ID")
-	if os.Getenv("SKYTAP_TEMPLATE_NEW_ENV_ID") != "" {
-		newEnvTemplateID = os.Getenv("SKYTAP_TEMPLATE_NEW_ENV_ID")
-		log.Printf("[DEBUG] SKYTAP_TEMPLATE_NEW_ENV_ID=%s", newEnvTemplateID)
-	}
-	return templateSet, vmSet, newEnvTemplateID
+func setupEnvironmentWithKeys(templateKey string, templateIDFallback string, vmKey string, vmIDFallback string) (string, string, string) {
+	templateID := getEnv(templateKey, templateIDFallback)
+	vmID := getEnv(vmKey, vmIDFallback)
+	newEnvTemplateID := getEnv("SKYTAP_TEMPLATE_NEW_ENV_ID", templateID)
+	return templateID, vmID, newEnvTemplateID
 }
 
-func setEnv(t *testing.T, key string, value string) bool {
-	if os.Getenv(key) == "" {
-		log.Printf("[WARN] variable required to run skytap_vm_resource acceptance tests. Setting: %s=%s", key, value)
-		err := os.Setenv(key, value)
-		assert.NoError(t, err)
-		return true
-	}
-	return false
+func setupEnvironment(templateIDFallback string, vmIDFallback string) (string, string, string) {
+	return setupEnvironmentWithKeys("SKYTAP_TEMPLATE_ID", templateIDFallback, "SKYTAP_VM_ID", vmIDFallback)
 }
 
-func unsetEnv(variable string) {
-	err := os.Unsetenv(variable)
-	if err != nil {
-		log.Printf("[ERROR] could not unset environment variable (%s)", variable)
+func getEnv(key, fallback string) string {
+	value := fallback
+	if v, ok := os.LookupEnv(key); ok {
+		value = v
 	}
+	log.Printf("[DEBUG] %s=%s", key, value)
+	return value
 }
 
 func testAccSkytapVMConfig_cassandra(envTemplateID string, templateID string, vmID string, uniqueSuffixEnv int, existingPort int, extraPublishedService string, extraNIC string) string {

--- a/skytap/structures.go
+++ b/skytap/structures.go
@@ -98,8 +98,11 @@ func buildServices(interfaces *schema.Set) (map[string]int, map[string]string) {
 			publishedServices := networkInterface["published_service"].(*schema.Set)
 			for _, v := range publishedServices.List() {
 				publishedService := v.(map[string]interface{})
-				ips[publishedService["name"].(string)] = publishedService["external_ip"].(string)
-				ports[publishedService["name"].(string)] = publishedService["external_port"].(int)
+				// check if terraform is managing the published services
+				if publishedService["name"] != nil {
+					ips[publishedService["name"].(string)] = publishedService["external_ip"].(string)
+					ports[publishedService["name"].(string)] = publishedService["external_port"].(int)
+				}
 			}
 		}
 	}

--- a/skytap/utils/utils.go
+++ b/skytap/utils/utils.go
@@ -1,6 +1,9 @@
 package utils
 
 import (
+	"log"
+	"os"
+
 	"github.com/skytap/skytap-sdk-go/skytap"
 )
 
@@ -27,4 +30,13 @@ func VMRunstate(runstate skytap.VMRunstate) *skytap.VMRunstate {
 // NICType returns a pointer to a NICType literal
 func NICType(nicType skytap.NICType) *skytap.NICType {
 	return &nicType
+}
+
+func GetEnv(key, fallback string) string {
+	value := fallback
+	if v, ok := os.LookupEnv(key); ok {
+		value = v
+	}
+	log.Printf("[DEBUG] %s=%s", key, value)
+	return value
 }

--- a/vendor/github.com/skytap/skytap-sdk-go/skytap/vm.go
+++ b/vendor/github.com/skytap/skytap-sdk-go/skytap/vm.go
@@ -501,7 +501,7 @@ func (s *VMsServiceClient) waitForRunstate(ctx *context.Context, environmentID s
 
 		if makeRequest {
 			seconds := s.client.retryAfter
-			log.Printf("[INFO] retrying after %d second(s)\n", seconds)
+			log.Printf("[INFO] waiting for %d second(s)\n", seconds)
 			time.Sleep(time.Duration(seconds) * time.Second)
 		} else {
 			log.Printf("[INFO] runstate is now (%s)\n", string(runstate))

--- a/vendor/github.com/skytap/skytap-sdk-go/skytap/vm.go
+++ b/vendor/github.com/skytap/skytap-sdk-go/skytap/vm.go
@@ -286,14 +286,17 @@ func (s *VMsServiceClient) Create(ctx context.Context, environmentID string, opt
 
 	// The create method returns an environment. The ID of the VM is not specified.
 	// It is necessary to retrieve the most recently created vm.
-	createdVM := mostRecentVM(createdEnvironment.VMs)
+	createdVM, err := mostRecentVM(&createdEnvironment)
+	if err != nil {
+		return nil, err
+	}
 
 	return createdVM, nil
 }
 
 // Update a vm
 func (s *VMsServiceClient) Update(ctx context.Context, environmentID string, id string, opts *UpdateVMRequest) (*VM, error) {
-	if opts.Runstate != nil {
+	if opts.Runstate != nil && opts.Hardware == nil {
 		return s.changeRunstate(ctx, environmentID, id, opts)
 	} else if opts.Hardware == nil || opts.Hardware.UpdateDisks == nil || opts.Hardware.UpdateDisks.DiskIdentification == nil {
 		return nil, fmt.Errorf("expecting the DiskIdentification list to be populated")
@@ -319,13 +322,17 @@ func (s *VMsServiceClient) Delete(ctx context.Context, environmentID string, id 
 }
 
 // mostRecentVM returns the mose recent VM given a list of VMs
-func mostRecentVM(vms []VM) *VM {
+func mostRecentVM(environment *Environment) (*VM, error) {
+	vms := environment.VMs
+	if len(vms) == 0 {
+		return nil, fmt.Errorf("could not find any VMs in environment (%s)", *environment.ID)
+	}
 	sort.Slice(vms, func(i, j int) bool {
 		time1, _ := time.Parse(timestampFormat, *vms[i].CreatedAt)
 		time2, _ := time.Parse(timestampFormat, *vms[j].CreatedAt)
 		return time1.After(time2)
 	})
-	return &vms[0]
+	return &vms[0], nil
 }
 
 func (s *VMsServiceClient) updateHardware(ctx context.Context, environmentID string, id string, opts *UpdateVMRequest) (*VM, error) {
@@ -337,6 +344,9 @@ func (s *VMsServiceClient) updateHardware(ctx context.Context, environmentID str
 	opts.Hardware.UpdateDisks.DiskIdentification = nil
 
 	currentVM, err := s.Get(ctx, environmentID, id)
+	if err != nil {
+		return nil, err
+	}
 	// if started stop
 	runstate := currentVM.Runstate
 	if *runstate == VMRunstateRunning {
@@ -376,6 +386,9 @@ func (s *VMsServiceClient) updateHardware(ctx context.Context, environmentID str
 		return nil, err
 	}
 	updatedVM, err = s.Get(ctx, environmentID, id)
+	if err != nil {
+		return nil, err
+	}
 
 	matchUpExistingDisks(updatedVM, diskIdentification, removes)
 	matchUpNewDisks(updatedVM, diskIdentification, removes)
@@ -402,7 +415,9 @@ func (s *VMsServiceClient) updateHardware(ctx context.Context, environmentID str
 			return nil, err
 		}
 		updatedVM, err = s.Get(ctx, environmentID, id)
-
+		if err != nil {
+			return nil, err
+		}
 		// update new list of disks
 		updateFinalDiskList(updatedVM, disks)
 	}
@@ -478,7 +493,6 @@ func (s *VMsServiceClient) waitForRunstate(ctx *context.Context, environmentID s
 	var err error
 	for i := 0; i < s.client.retryCount+1 && makeRequest; i++ {
 		vm, err := s.Get(*ctx, environmentID, id)
-
 		if err != nil {
 			break
 		}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -757,10 +757,10 @@
 			"revisionTime": "2018-09-10T08:07:58Z"
 		},
 		{
-			"checksumSHA1": "O5S83Z2heS0lA4uEbo0D8XqbNq8=",
+			"checksumSHA1": "NTCOhJRdPuzQcjj6tbS3Er2fAEo=",
 			"path": "github.com/skytap/skytap-sdk-go/skytap",
-			"revision": "529cd6ba2e5c57e5b830690b73fce8074e3c43e1",
-			"revisionTime": "2018-12-21T10:23:05Z",
+			"revision": "afa083a90f321f170a43211990a7380f59fdc1b8",
+			"revisionTime": "2018-12-30T17:54:23Z",
 			"version": "v2",
 			"versionExact": "v2"
 		},

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -757,10 +757,10 @@
 			"revisionTime": "2018-09-10T08:07:58Z"
 		},
 		{
-			"checksumSHA1": "NTCOhJRdPuzQcjj6tbS3Er2fAEo=",
+			"checksumSHA1": "5prWc7RxBp+FW8LLC/KlfdgOU7w=",
 			"path": "github.com/skytap/skytap-sdk-go/skytap",
-			"revision": "afa083a90f321f170a43211990a7380f59fdc1b8",
-			"revisionTime": "2018-12-30T17:54:23Z",
+			"revision": "ca05522dfcbc104f97801451b750acafccd09f39",
+			"revisionTime": "2019-01-01T18:56:23Z",
 			"version": "v2",
 			"versionExact": "v2"
 		},


### PR DESCRIPTION
1. The tests were failing because environment variables were not being unset at the end of each test - if used.
2. Update SDK version to fix panics and error handling.

Note to reviewer: review all other pull requests in sequence. They build on each other. Once each is merged to master then the size of each subsequent PR will decrease.