### PR TITLE
26 Add unique User-Agent when making calls to Skytap API

### DIFF
--- a/skytap/config.go
+++ b/skytap/config.go
@@ -2,7 +2,6 @@ package skytap
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"log"
 
@@ -67,12 +66,6 @@ func (c *Config) createClient() (*skytap.Client, error) {
 }
 
 func getUserAgent() (string, error) {
-	var userAgent userAgent
-	err := json.Unmarshal([]byte(userAgentVersion), &userAgent)
-	if err != nil {
-		return "", err
-	}
-
-	log.Printf("[DEBUG] user agent version.go: %s", userAgent.Version)
-	return fmt.Sprintf("tf-%s", userAgent.Version), nil
+	log.Printf("[DEBUG] user agent version (version.go): %s", userAgentVersion)
+	return fmt.Sprintf("terraform-provider-skytap/%s", userAgentVersion), nil
 }

--- a/skytap/config_test.go
+++ b/skytap/config_test.go
@@ -1,6 +1,7 @@
 package skytap
 
 import (
+	"regexp"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -12,7 +13,10 @@ func TestUserAgent(t *testing.T) {
 	}
 
 	userAgent, err := getUserAgent()
-	assert.True(t, len(userAgent) > 3)
+
+	matched, err := regexp.Match(`terraform-provider-skytap/\d+\.\d+\.\d+`, []byte(userAgent))
+
+	assert.True(t, matched, "Not matched")
 
 	client, err := config.createClient()
 

--- a/skytap/config_test.go
+++ b/skytap/config_test.go
@@ -1,0 +1,21 @@
+package skytap
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUserAgent(t *testing.T) {
+	config := &Config{
+		APIToken: "abc123",
+	}
+
+	userAgent, err := getUserAgent()
+	assert.True(t, len(userAgent) > 3)
+
+	client, err := config.createClient()
+
+	assert.NoError(t, err)
+	assert.Equal(t, userAgent, client.UserAgent)
+}

--- a/skytap/version.go
+++ b/skytap/version.go
@@ -1,9 +1,3 @@
 package skytap
 
-const userAgentVersion = `{
-  "version": "0.11.x"
-}`
-
-type userAgent struct {
-	Version string `json:"version"`
-}
+const userAgentVersion = "0.11.0"

--- a/skytap/version.go
+++ b/skytap/version.go
@@ -1,0 +1,9 @@
+package skytap
+
+const userAgentVersion = `{
+  "version": "0.11.x"
+}`
+
+type userAgent struct {
+	Version string `json:"version"`
+}


### PR DESCRIPTION
Read the version from a file. If necessary we can extend this by modifying the make file to read from the version and update this file. Perhaps from the commit log.