### PR TITLE
Bumping the skytap-go-sdk version to 2.1.0 and fixing acceptance tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
-## 0.15.0 (Unreleased)
+## 0.14.1 (Unreleased)
+
+BUG FIXES:
+* `resource/skytap_vm` : Fixed provider panic message when creating a VM with two disks while setting one of those CPU/RAM/Name properties.
+* `resource/skytap_vm` : Fixed provider hanging when new disks are added while old ones are removed.
+
 ## 0.14.0 (March 26, 2020)
 
 FEATURES:

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -15,7 +15,7 @@ test: fmtcheck
 		xargs -t -n4 go test $(TESTARGS) -timeout=30s -parallel=4
 
 testacc: fmtcheck
-	TF_ACC=1 go test $(TEST) -v $(TESTARGS) -timeout 180m
+	TF_ACC=1 go test $(TEST) -v $(TESTARGS) -timeout 240m
 
 vet:
 	@echo "go vet ."

--- a/go.mod
+++ b/go.mod
@@ -7,8 +7,7 @@ require (
 	github.com/google/go-cmp v0.3.1 // indirect
 	github.com/hashicorp/terraform-plugin-sdk v1.1.0
 	github.com/mattn/go-colorable v0.1.1 // indirect
-
-	github.com/skytap/skytap-sdk-go v0.0.0-20200326114958-9341ee33a77e
+	github.com/skytap/skytap-sdk-go v0.0.0-20200416085108-e442918ac42d
 	github.com/stretchr/testify v1.3.0
 	github.com/vmihailenco/msgpack v4.0.1+incompatible // indirect
 	golang.org/x/net v0.0.0-20191009170851-d66e71096ffb // indirect

--- a/go.sum
+++ b/go.sum
@@ -180,8 +180,8 @@ github.com/posener/complete v1.2.1 h1:LrvDIY//XNo65Lq84G/akBuMGlawHvGBABv8f/ZN6D
 github.com/posener/complete v1.2.1/go.mod h1:6gapUrK/U1TAN7ciCoNRIdVC5sbdBTUh1DKN0g6uH7E=
 github.com/sergi/go-diff v1.0.0 h1:Kpca3qRNrduNnOQeazBd0ysaKrUJiIuISHxogkT9RPQ=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
-github.com/skytap/skytap-sdk-go v0.0.0-20200326114958-9341ee33a77e h1:m6kWqvAAhNcPV8gmPIDWrL48SHCHTF2oUU0xYLTwRpk=
-github.com/skytap/skytap-sdk-go v0.0.0-20200326114958-9341ee33a77e/go.mod h1:V1HX7VGGylkRYjgyftn7vnOUZ7yOnTfwKsoZUHLkk1w=
+github.com/skytap/skytap-sdk-go v0.0.0-20200416085108-e442918ac42d h1:0tvtRktKLxPSXKy8jnGuV8/qYF/wQKwhPyDYp2FaQsM=
+github.com/skytap/skytap-sdk-go v0.0.0-20200416085108-e442918ac42d/go.mod h1:V1HX7VGGylkRYjgyftn7vnOUZ7yOnTfwKsoZUHLkk1w=
 github.com/spf13/afero v1.2.2 h1:5jhuqJyZCZf2JRofRvN/nIFgIWNzPa3/Vz8mYylgbWc=
 github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=
 github.com/spf13/pflag v1.0.2/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=

--- a/skytap/resource_label_category_test.go
+++ b/skytap/resource_label_category_test.go
@@ -98,6 +98,9 @@ func TestAccSkytapLabelCategory_Duplicated(t *testing.T) {
 		}
 		
 		resource skytap_label_category "duplabel2" {
+		  // making sure the first category is created before trying to create the second
+		  // to avoid flakiness.
+          depends_on = [skytap_label_category.duplabel1]
 		  name = "tftest-dup"
 		  single_value = true
 		}

--- a/skytap/resource_skytap_vm_test.go
+++ b/skytap/resource_skytap_vm_test.go
@@ -627,7 +627,7 @@ func TestAccSkytapVMCPURAM_Invalid(t *testing.T) {
 }
 
 func TestAccSkytapVMCPU_OutOfRange(t *testing.T) {
-	templateID, vmID, newEnvTemplateID := setupNonDefaultEnvironment("SKYTAP_TEMPLATE_OUTOFRANGE_ID", "136409", "SKYTAP_VM_OUTOFRANGE_ID", "849656")
+	templateID, vmID, newEnvTemplateID := setupNonDefaultEnvironment("SKYTAP_TEMPLATE_OUTOFRANGE_ID", "1877151", "SKYTAP_VM_OUTOFRANGE_ID", "66413705")
 	uniqueSuffixEnv := acctest.RandInt()
 
 	resource.Test(t, resource.TestCase{
@@ -646,7 +646,7 @@ func TestAccSkytapVMCPU_OutOfRange(t *testing.T) {
 }
 
 func TestAccSkytapVMCPU_OutOfRangeAfterUpdate(t *testing.T) {
-	templateID, vmID, newEnvTemplateID := setupNonDefaultEnvironment("SKYTAP_TEMPLATE_OUTOFRANGE_ID", "136409", "SKYTAP_VM_OUTOFRANGE_ID", "849656")
+	templateID, vmID, newEnvTemplateID := setupNonDefaultEnvironment("SKYTAP_TEMPLATE_OUTOFRANGE_ID", "1877151", "SKYTAP_VM_OUTOFRANGE_ID", "66413705")
 	uniqueSuffixEnv := acctest.RandInt()
 
 	resource.Test(t, resource.TestCase{
@@ -710,7 +710,7 @@ func TestAccSkytapVMDisks_Create(t *testing.T) {
 								size = 2048
 								name = "smaller2"  # stays the same
 							  }
-
+			
 							  disk {
 								size = 2049
 								name = "bigger2" # new

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -205,7 +205,7 @@ github.com/posener/complete
 github.com/posener/complete/cmd
 github.com/posener/complete/cmd/install
 github.com/posener/complete/match
-# github.com/skytap/skytap-sdk-go v0.0.0-20200227143306-3ef7a9bc603a
+# github.com/skytap/skytap-sdk-go v0.0.0-20200416085108-e442918ac42d
 github.com/skytap/skytap-sdk-go/skytap
 # github.com/spf13/afero v1.2.2
 github.com/spf13/afero


### PR DESCRIPTION
Updating the skytap-sdk-go to fix 
* Provider panic message when creating a VM with two disks while setting one of those CPU/RAM/Name properties.
* Provider hanging when new disks are added while old ones are removed.

I've also updated the acceptance tests to fix a missing template and to make it less flaky

<details><summary>Acceptance Test Results</summary>
<p>

Acceptance Test runs

?       github.com/terraform-providers/terraform-provider-skytap        [no test files]
=== RUN   TestUserAgent
2020/04/16 10:46:35 [DEBUG] user agent version (version.go): 0.12.1
2020/04/16 10:46:35 [DEBUG] user agent version (version.go): 0.12.1
--- PASS: TestUserAgent (0.00s)
=== RUN   TestAccDataSourceSkytapProject_Basic
=== PAUSE TestAccDataSourceSkytapProject_Basic
=== RUN   TestAccDataSourceSkytapTemplate_Basic
=== PAUSE TestAccDataSourceSkytapTemplate_Basic
=== RUN   TestAccDataSourceSkytapTemplate_RegexMostRecent
=== PAUSE TestAccDataSourceSkytapTemplate_RegexMostRecent
=== RUN   TestProvider
--- PASS: TestProvider (0.00s)
=== RUN   TestProvider_impl
--- PASS: TestProvider_impl (0.00s)
=== RUN   TestAccSkytapLabelCategory_Basic
--- PASS: TestAccSkytapLabelCategory_Basic (4.43s)
=== RUN   TestAccSkytapLabelCategory_Update
--- PASS: TestAccSkytapLabelCategory_Update (4.91s)
=== RUN   TestAccSkytapLabelCategory_MultiValueBasic
--- PASS: TestAccSkytapLabelCategory_MultiValueBasic (7.05s)
=== RUN   TestAccSkytapLabelCategory_Duplicated
--- PASS: TestAccSkytapLabelCategory_Duplicated (3.39s)
=== RUN   TestAccSkytapEnvironment_Basic
--- PASS: TestAccSkytapEnvironment_Basic (106.61s)
=== RUN   TestAccSkytapEnvironment_UpdateTemplate
--- PASS: TestAccSkytapEnvironment_UpdateTemplate (236.82s)
=== RUN   TestAccSkytapEnvironment_UpdateTags
--- PASS: TestAccSkytapEnvironment_UpdateTags (108.50s)
=== RUN   TestAccSkytapEnvironment_UserData
--- PASS: TestAccSkytapEnvironment_UserData (94.39s)
=== RUN   TestAccSkytapEnvironment_UserDataUpdate
--- PASS: TestAccSkytapEnvironment_UserDataUpdate (134.47s)
=== RUN   TestAccSkytapEnvironment_Labels
--- PASS: TestAccSkytapEnvironment_Labels (147.95s)
=== RUN   TestAccSkytapEnvironment_LabelsUpdate
--- PASS: TestAccSkytapEnvironment_LabelsUpdate (142.36s)
=== RUN   TestAccSkytapLabelICNR_Basic
--- PASS: TestAccSkytapLabelICNR_Basic (156.50s)
=== RUN   TestAccSkytapNetwork_Basic
=== PAUSE TestAccSkytapNetwork_Basic
=== RUN   TestAccSkytapNetwork_Update
=== PAUSE TestAccSkytapNetwork_Update
=== RUN   TestAccSkytapProject_Basic
=== PAUSE TestAccSkytapProject_Basic
=== RUN   TestAccSkytapVM_Basic
--- PASS: TestAccSkytapVM_Basic (290.32s)
=== RUN   TestAccSkytapVM_Timeout
--- PASS: TestAccSkytapVM_Timeout (286.86s)
=== RUN   TestAccSkytapVM_Update
--- PASS: TestAccSkytapVM_Update (425.72s)
=== RUN   TestAccSkytapVM_Interface
--- PASS: TestAccSkytapVM_Interface (805.50s)
=== RUN   TestAccSkytapVM_PublishedService
--- PASS: TestAccSkytapVM_PublishedService (973.21s)
=== RUN   TestAccSkytapVM_PublishedServiceBadNic
--- PASS: TestAccSkytapVM_PublishedServiceBadNic (194.39s)
=== RUN   TestAccExternalPorts
--- PASS: TestAccExternalPorts (416.89s)
=== RUN   TestAccSkytapVM_Typical
--- PASS: TestAccSkytapVM_Typical (607.27s)
=== RUN   TestAccSkytapVMCPURam_Create
--- PASS: TestAccSkytapVMCPURam_Create (775.32s)
=== RUN   TestAccSkytapVMCPU_DiskIntact
--- FAIL: TestAccSkytapVMCPU_DiskIntact (892.29s)
=== RUN   TestAccSkytapVMCPURAM_UpdateNPECheck
--- PASS: TestAccSkytapVMCPURAM_UpdateNPECheck (450.22s)
=== RUN   TestAccSkytapVMCPURAM_Invalid
--- PASS: TestAccSkytapVMCPURAM_Invalid (0.01s)
=== RUN   TestAccSkytapVMCPU_OutOfRange
--- PASS: TestAccSkytapVMCPU_OutOfRange (153.18s)
=== RUN   TestAccSkytapVMCPU_OutOfRangeAfterUpdate
--- PASS: TestAccSkytapVMCPU_OutOfRangeAfterUpdate (271.20s)
=== RUN   TestAccSkytapVMDisks_Create
--- PASS: TestAccSkytapVMDisks_Create (515.54s)
=== RUN   TestAccSkytapVMDisks_UpdateNPECheck
--- PASS: TestAccSkytapVMDisks_UpdateNPECheck (421.14s)
=== RUN   TestAccSkytapVMDisks_Resize
--- PASS: TestAccSkytapVMDisks_Resize (477.53s)
=== RUN   TestAccSkytapVMDisk_Invalid
--- PASS: TestAccSkytapVMDisk_Invalid (0.01s)
=== RUN   TestAccSkytapVMDisk_OS
--- PASS: TestAccSkytapVMDisk_OS (459.54s)
=== RUN   TestAccSkytapVMDisk_OSChangeAfter
--- PASS: TestAccSkytapVMDisk_OSChangeAfter (447.88s)
=== RUN   TestAccSkytapVM_Concurrent
--- FAIL: TestAccSkytapVM_Concurrent (704.14s)
=== RUN   TestAccSkytapVM_UserData
--- FAIL: TestAccSkytapVM_UserData (413.16s)
=== RUN   TestAccSkytapVM_Labels
--- FAIL: TestAccSkytapVM_Labels (19.31s)
=== RUN   TestFlattenInterfaces
--- PASS: TestFlattenInterfaces (0.00s)
=== RUN   TestFlattenPublishedServices
--- PASS: TestFlattenPublishedServices (0.00s)
=== RUN   TestFlattenDisks
--- PASS: TestFlattenDisks (0.00s)
=== RUN   TestValidateNICType
--- PASS: TestValidateNICType (0.00s)
=== RUN   TestValidateRoleType
--- PASS: TestValidateRoleType (0.00s)
=== RUN   TestValidateNoSubString
--- PASS: TestValidateNoSubString (0.00s)
=== RUN   TestValidateNoStartWith
--- PASS: TestValidateNoStartWith (0.00s)
=== CONT  TestAccDataSourceSkytapProject_Basic
=== CONT  TestAccSkytapNetwork_Update
--- FAIL: TestAccDataSourceSkytapProject_Basic (88.27s)
=== CONT  TestAccSkytapProject_Basic
--- FAIL: TestAccSkytapProject_Basic (15.32s)
=== CONT  TestAccDataSourceSkytapTemplate_RegexMostRecent
--- PASS: TestAccDataSourceSkytapTemplate_RegexMostRecent (149.43s)
=== CONT  TestAccSkytapNetwork_Basic
--- PASS: TestAccSkytapNetwork_Update (427.14s)
=== CONT  TestAccDataSourceSkytapTemplate_Basic
--- PASS: TestAccDataSourceSkytapTemplate_Basic (10.56s)
--- FAIL: TestAccSkytapNetwork_Basic (259.14s)
FAIL
FAIL    github.com/terraform-providers/terraform-provider-skytap/skytap 11660.513s
=== RUN   TestResponseErrorIsNotFound_BadRequest
--- PASS: TestResponseErrorIsNotFound_BadRequest (0.00s)
=== RUN   TestResponseErrorIsNotFound_NotFound
--- PASS: TestResponseErrorIsNotFound_NotFound (0.00s)
=== RUN   TestString
--- PASS: TestString (0.00s)
=== RUN   TestInt
--- PASS: TestInt (0.00s)
=== RUN   TestNetworkType
--- PASS: TestNetworkType (0.00s)
=== RUN   TestRunstate
--- PASS: TestRunstate (0.00s)
=== RUN   TestBool
--- PASS: TestBool (0.00s)
PASS
ok      github.com/terraform-providers/terraform-provider-skytap/skytap/utils   0.412s
FAIL

Re-running failed tests (Re-run 01):

=== RUN   TestAccDataSourceSkytapProject_Basic
=== PAUSE TestAccDataSourceSkytapProject_Basic
=== RUN   TestAccSkytapNetwork_Basic
=== PAUSE TestAccSkytapNetwork_Basic
=== RUN   TestAccSkytapProject_Basic
=== PAUSE TestAccSkytapProject_Basic
=== RUN   TestAccSkytapVMCPU_DiskIntact
2020/04/16 14:43:14 [DEBUG] SKYTAP_TEMPLATE_ID=1473407
2020/04/16 14:43:14 [DEBUG] SKYTAP_VM_ID=37865463
2020/04/16 14:43:14 [DEBUG] SKYTAP_TEMPLATE_NEW_ENV_ID=1473407
--- FAIL: TestAccSkytapVMCPU_DiskIntact (878.61s)
=== RUN   TestAccSkytapVM_Concurrent
--- FAIL: TestAccSkytapVM_Concurrent (719.53s)
=== RUN   TestAccSkytapVM_UserData
--- PASS: TestAccSkytapVM_UserData (266.52s)
=== RUN   TestAccSkytapVM_Labels
--- PASS: TestAccSkytapVM_Labels (320.58s)
=== CONT  TestAccDataSourceSkytapProject_Basic
=== CONT  TestAccSkytapProject_Basic
=== CONT  TestAccSkytapNetwork_Basic
--- PASS: TestAccSkytapProject_Basic (3.74s)
--- PASS: TestAccDataSourceSkytapProject_Basic (6.30s)
--- PASS: TestAccSkytapNetwork_Basic (156.31s)
FAIL
FAIL    github.com/terraform-providers/terraform-provider-skytap/skytap 2342.360s
FAIL

Re-running failed tests (Re-run 02):

=== RUN   TestAccSkytapVMCPU_DiskIntact
2020/04/16 15:25:55 [DEBUG] SKYTAP_TEMPLATE_ID=1473407
2020/04/16 15:25:55 [DEBUG] SKYTAP_VM_ID=37865463
2020/04/16 15:25:55 [DEBUG] SKYTAP_TEMPLATE_NEW_ENV_ID=1473407
--- PASS: TestAccSkytapVMCPU_DiskIntact (462.59s)
=== RUN   TestAccSkytapVM_Concurrent
--- FAIL: TestAccSkytapVM_Concurrent (858.48s)
FAIL
FAIL    github.com/terraform-providers/terraform-provider-skytap/skytap 1321.707s
FAIL

Re-running failed tests (Re-run 03):

=== RUN   TestAccSkytapVM_Concurrent
2020/04/16 16:07:15 [DEBUG] SKYTAP_TEMPLATE_ID=1473407
2020/04/16 16:07:15 [DEBUG] SKYTAP_VM_ID=37865463
2020/04/16 16:07:15 [DEBUG] SKYTAP_TEMPLATE_NEW_ENV_ID=1473407
--- PASS: TestAccSkytapVM_Concurrent (750.48s)
PASS
ok      github.com/terraform-providers/terraform-provider-skytap/skytap 751.029s
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-skytap/skytap/utils   (cached) [no tests to run]


</p>
</details>