### PR TITLE
Add environment_ids attribute to project resource

### DIFF
--- a/docs/data-sources/project.md
+++ b/docs/data-sources/project.md
@@ -40,5 +40,6 @@ data "skytap_project" "example" {
 ### Read-Only
 
 - **auto_add_role_name** (String) The role automatically assigned to every new user added to the project
+- **environment_ids** (Set of String) IDs of the environments within the project
 - **show_project_members** (Boolean) Whether project members can view a list of the other project members
 - **summary** (String) The summary description of the project

--- a/docs/resources/project.md
+++ b/docs/resources/project.md
@@ -32,6 +32,7 @@ resource "skytap_project" "project" {
 ### Optional
 
 - **auto_add_role_name** (String) If this field is set to `viewer`, `participant`, `editor`, or `manager`, new users added to your Skytap account are automatically added to this project with the specified project role. Existing users aren’t affected by this setting. For additional details, see [Automatically adding new users to a project](https://help.skytap.com/csh-project-automatic-role.html)
+- **environment_ids** (Set of String) A list of environments to add to the project
 - **id** (String) The ID of this resource.
 - **show_project_members** (Boolean) Whether project members can view a list of other project members
 - **summary** (String) User-defined description of the project

--- a/go.mod
+++ b/go.mod
@@ -5,10 +5,8 @@ require (
 	github.com/davecgh/go-spew v1.1.1
 	github.com/hashicorp/terraform-plugin-docs v0.4.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.5.0
-	github.com/skytap/skytap-sdk-go v0.0.0-20200416085108-e442918ac42d
+	github.com/skytap/skytap-sdk-go v0.0.0-20210602165100-9d8dca474ca4
 	github.com/stretchr/testify v1.6.1
 )
-
-replace github.com/skytap/skytap-sdk-go v0.0.0-20200416085108-e442918ac42d => github.com/opencredo/skytap-sdk-go v0.0.0-20210514144139-4fe3119d1939
 
 go 1.13

--- a/go.mod
+++ b/go.mod
@@ -9,4 +9,6 @@ require (
 	github.com/stretchr/testify v1.6.1
 )
 
+replace github.com/skytap/skytap-sdk-go v0.0.0-20200416085108-e442918ac42d => github.com/opencredo/skytap-sdk-go v0.0.0-20210514144139-4fe3119d1939
+
 go 1.13

--- a/go.sum
+++ b/go.sum
@@ -309,6 +309,8 @@ github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce h1:RPclfga2SEJmgMmz2k
 github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce/go.mod h1:uFMI8w+ref4v2r9jz+c9i1IfIttS/OkmLfrk1jne5hs=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
+github.com/opencredo/skytap-sdk-go v0.0.0-20210514144139-4fe3119d1939 h1:nsjxwBQp8mkpDaZQ+uq/6SKg0StvvLySdI0wZ0YPNtI=
+github.com/opencredo/skytap-sdk-go v0.0.0-20210514144139-4fe3119d1939/go.mod h1:V1HX7VGGylkRYjgyftn7vnOUZ7yOnTfwKsoZUHLkk1w=
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
@@ -325,8 +327,6 @@ github.com/russross/blackfriday v1.6.0/go.mod h1:ti0ldHuxg49ri4ksnFxlkCfN+hvslNl
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/sergi/go-diff v1.1.0 h1:we8PVUC3FE2uYfodKH/nBHMSetSfHDR6scGdBi+erh0=
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
-github.com/skytap/skytap-sdk-go v0.0.0-20200416085108-e442918ac42d h1:0tvtRktKLxPSXKy8jnGuV8/qYF/wQKwhPyDYp2FaQsM=
-github.com/skytap/skytap-sdk-go v0.0.0-20200416085108-e442918ac42d/go.mod h1:V1HX7VGGylkRYjgyftn7vnOUZ7yOnTfwKsoZUHLkk1w=
 github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=
 github.com/spf13/pflag v1.0.2/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=

--- a/go.sum
+++ b/go.sum
@@ -309,8 +309,6 @@ github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce h1:RPclfga2SEJmgMmz2k
 github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce/go.mod h1:uFMI8w+ref4v2r9jz+c9i1IfIttS/OkmLfrk1jne5hs=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
-github.com/opencredo/skytap-sdk-go v0.0.0-20210514144139-4fe3119d1939 h1:nsjxwBQp8mkpDaZQ+uq/6SKg0StvvLySdI0wZ0YPNtI=
-github.com/opencredo/skytap-sdk-go v0.0.0-20210514144139-4fe3119d1939/go.mod h1:V1HX7VGGylkRYjgyftn7vnOUZ7yOnTfwKsoZUHLkk1w=
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
@@ -327,6 +325,8 @@ github.com/russross/blackfriday v1.6.0/go.mod h1:ti0ldHuxg49ri4ksnFxlkCfN+hvslNl
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/sergi/go-diff v1.1.0 h1:we8PVUC3FE2uYfodKH/nBHMSetSfHDR6scGdBi+erh0=
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
+github.com/skytap/skytap-sdk-go v0.0.0-20210602165100-9d8dca474ca4 h1:4RtgZctkF7L1mdGEsN252pVK3gqWTsJKzDxzc0H4G5o=
+github.com/skytap/skytap-sdk-go v0.0.0-20210602165100-9d8dca474ca4/go.mod h1:V1HX7VGGylkRYjgyftn7vnOUZ7yOnTfwKsoZUHLkk1w=
 github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=
 github.com/spf13/pflag v1.0.2/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=

--- a/skytap/data_source_skytap_project.go
+++ b/skytap/data_source_skytap_project.go
@@ -41,6 +41,15 @@ func dataSourceSkytapProject() *schema.Resource {
 				Computed:    true,
 				Description: "Whether project members can view a list of the other project members",
 			},
+
+			"environment_ids": {
+				Type:        schema.TypeSet,
+				Computed:    true,
+				Description: "IDs of the environments within the project",
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
 		},
 	}
 }
@@ -87,6 +96,15 @@ func dataSourceSkytapProjectRead(ctx context.Context, d *schema.ResourceData, me
 		return diag.FromErr(err)
 	}
 	err = d.Set("show_project_members", project.ShowProjectMembers)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	environments, err := client.ListEnvironments(ctx, *project.ID)
+	if err != nil {
+		return diag.Errorf("error retrieving project environments: %v", err)
+	}
+	err = d.Set("environment_ids", flattenProjectEnvironments(environments.Value))
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/skytap/data_source_skytap_project_test.go
+++ b/skytap/data_source_skytap_project_test.go
@@ -9,7 +9,8 @@ import (
 )
 
 func TestAccDataSourceSkytapProject_Basic(t *testing.T) {
-	rInt := acctest.RandInt()
+	templateID, _, _ := setupEnvironment()
+	uniqueSuffix := acctest.RandInt()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
@@ -17,27 +18,35 @@ func TestAccDataSourceSkytapProject_Basic(t *testing.T) {
 		CheckDestroy:      testAccCheckSkytapProjectDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceSkytapProjectConfig_basic(rInt),
+				Config: testAccDataSourceSkytapProjectConfig_basic(templateID, uniqueSuffix),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSkytapProjectExists("data.skytap_project.bar"),
-					resource.TestCheckResourceAttr("data.skytap_project.bar", "name", fmt.Sprintf("tftest-project-data-%d", rInt)),
+					resource.TestCheckResourceAttr("data.skytap_project.bar", "name", fmt.Sprintf("tftest-project-data-%d", uniqueSuffix)),
 					resource.TestCheckResourceAttrSet("data.skytap_project.bar", "summary"),
 					resource.TestCheckResourceAttr("data.skytap_project.bar", "auto_add_role_name", ""),
 					resource.TestCheckResourceAttr("data.skytap_project.bar", "show_project_members", "true"),
+					resource.TestCheckTypeSetElemAttrPair("data.skytap_project.bar", "environment_ids.*", "skytap_environment.foo", "id"),
 				),
 			},
 		},
 	})
 }
 
-func testAccDataSourceSkytapProjectConfig_basic(rInt int) string {
+func testAccDataSourceSkytapProjectConfig_basic(envTemplateID string, uniqueSuffix int) string {
 	return fmt.Sprintf(`
 resource "skytap_project" "foo" {
 	name = "tftest-project-data-%d"
 	summary = "This is a project created by the skytap terraform provider acceptance test"
+	environment_ids = [skytap_environment.foo.id]
+}
+
+resource "skytap_environment" "foo" {
+	template_id = "%s"
+	name 		= "%s-environment-%d"
+	description = "This is an environment to support a skytap project terraform provider acceptance test"
 }
 
 data "skytap_project" "bar" {
 	name = "${skytap_project.foo.name}"
-}`, rInt)
+}`, uniqueSuffix, envTemplateID, vmEnvironmentPrefix, uniqueSuffix)
 }

--- a/skytap/resource_skytap_project.go
+++ b/skytap/resource_skytap_project.go
@@ -56,6 +56,14 @@ func resourceSkytapProject() *schema.Resource {
 				Default:     true,
 				Description: "Whether project members can view a list of other project members",
 			},
+
+			"environment_ids": {
+				Type: schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
 		},
 	}
 }
@@ -92,6 +100,14 @@ func resourceSkytapProjectCreate(ctx context.Context, d *schema.ResourceData, me
 	}
 	projectID := strconv.Itoa(*project.ID)
 	d.SetId(projectID)
+
+	environmentIDs := d.Get("environment_ids").(*schema.Set)
+	for _, environmentID := range environmentIDs.List() {
+		_, err := client.AddEnvironment(ctx, *project.ID, environmentID.(string))
+		if err != nil {
+			return diag.Errorf("error adding environment to project: %v", err)
+		}
+	}
 
 	log.Printf("[INFO] project created: %d", *project.ID)
 	log.Printf("[TRACE] project created: %v", spew.Sdump(project))
@@ -136,6 +152,15 @@ func resourceSkytapProjectRead(ctx context.Context, d *schema.ResourceData, meta
 		return diag.FromErr(err)
 	}
 
+	environments, err := client.ListEnvironments(ctx, id)
+	if err != nil {
+		return diag.Errorf("error retrieving project environments: %v", err)
+	}
+	err = d.Set("environment_ids", flattenProjectEnvironments(environments.Value))
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
 	log.Printf("[INFO] project retrieved: %d", id)
 	log.Printf("[TRACE] project retrieved: %v", spew.Sdump(project))
 
@@ -172,6 +197,22 @@ func resourceSkytapProjectUpdate(ctx context.Context, d *schema.ResourceData, me
 	project, err := client.Update(ctx, id, &opts)
 	if err != nil {
 		return diag.Errorf("error updating project (%d): %v", id, err)
+	}
+
+	oldEnvIDs, newEnvIds := d.GetChange("environment_ids")
+	addedEnvs := newEnvIds.(*schema.Set).Difference(oldEnvIDs.(*schema.Set))
+	removedEnvs := oldEnvIDs.(*schema.Set).Difference(newEnvIds.(*schema.Set))
+	for _, envID := range addedEnvs.List() {
+		_, err := client.AddEnvironment(ctx, id, envID.(string))
+		if err != nil {
+			return diag.Errorf("error adding environment to project: %v", err)
+		}
+	}
+	for _, envID := range removedEnvs.List() {
+		err := client.RemoveEnvironment(ctx, id, envID.(string))
+		if err != nil {
+			return diag.Errorf("error removing environment from project: %v", err)
+		}
 	}
 
 	log.Printf("[INFO] project updated: %d", id)

--- a/skytap/resource_skytap_project.go
+++ b/skytap/resource_skytap_project.go
@@ -58,11 +58,12 @@ func resourceSkytapProject() *schema.Resource {
 			},
 
 			"environment_ids": {
-				Type: schema.TypeSet,
+				Type:     schema.TypeSet,
 				Optional: true,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
 				},
+				Description: "A list of environments to add to the project",
 			},
 		},
 	}

--- a/skytap/structures.go
+++ b/skytap/structures.go
@@ -109,6 +109,22 @@ func flattenLabels(labels []*skytap.Label) []interface{} {
 	return flatted
 }
 
+func flattenProjectIDs(projects []skytap.Project) []interface{} {
+	flattened := make([]interface{}, len(projects))
+	for i, v := range projects {
+		flattened[i] = v.ID
+	}
+	return flattened
+}
+
+func flattenProjectEnvironments(environments []skytap.ProjectEnvironment) []interface{} {
+	flattened := make([]interface{}, len(environments))
+	for i, v := range environments {
+		flattened[i] = v.ID
+	}
+	return flattened
+}
+
 func getVMNetworkInterface(id string, vm *skytap.VM) (*skytap.Interface, error) {
 	for _, networkInterface := range vm.Interfaces {
 		if *networkInterface.ID == id {

--- a/vendor/github.com/skytap/skytap-sdk-go/skytap/environment.go
+++ b/vendor/github.com/skytap/skytap-sdk-go/skytap/environment.go
@@ -25,6 +25,7 @@ type EnvironmentsService interface {
 	CreateLabels(ctx context.Context, id string, createLabelRequest []*CreateLabelRequest) error
 	DeleteLabel(ctx context.Context, id string, labelId string) error
 	UpdateUserData(ctx context.Context, id string, userData *string) error
+	ListProjects(ctx context.Context, id string) (*ProjectListResult, error)
 }
 
 // EnvironmentsServiceClient is the EnvironmentsService implementation
@@ -457,6 +458,28 @@ func (s *EnvironmentsServiceClient) UpdateUserData(ctx context.Context, id strin
 	}
 
 	return nil
+}
+
+func (s *EnvironmentsServiceClient) ListProjects(ctx context.Context, id string) (*ProjectListResult, error) {
+	path := fmt.Sprintf("%s/%s/projects", environmentBasePath, id)
+
+	req, err := s.client.newRequest(ctx, "GET", path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	err = s.client.setRequestListParameters(req, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var projectListResponse ProjectListResult
+	_, err = s.client.do(ctx, req, &projectListResponse.Value, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return &projectListResponse, nil
 }
 
 func (payload *CreateEnvironmentRequest) compareResponse(ctx context.Context, c *Client, v interface{}, state *environmentVMRunState) (string, bool) {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -357,7 +357,7 @@ github.com/posener/complete/cmd/install
 github.com/posener/complete/match
 # github.com/russross/blackfriday v1.6.0
 github.com/russross/blackfriday
-# github.com/skytap/skytap-sdk-go v0.0.0-20200416085108-e442918ac42d => github.com/opencredo/skytap-sdk-go v0.0.0-20210514144139-4fe3119d1939
+# github.com/skytap/skytap-sdk-go v0.0.0-20210602165100-9d8dca474ca4
 github.com/skytap/skytap-sdk-go/skytap
 # github.com/stretchr/testify v1.6.1
 github.com/stretchr/testify/assert

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -357,7 +357,7 @@ github.com/posener/complete/cmd/install
 github.com/posener/complete/match
 # github.com/russross/blackfriday v1.6.0
 github.com/russross/blackfriday
-# github.com/skytap/skytap-sdk-go v0.0.0-20200416085108-e442918ac42d
+# github.com/skytap/skytap-sdk-go v0.0.0-20200416085108-e442918ac42d => github.com/opencredo/skytap-sdk-go v0.0.0-20210514144139-4fe3119d1939
 github.com/skytap/skytap-sdk-go/skytap
 # github.com/stretchr/testify v1.6.1
 github.com/stretchr/testify/assert


### PR DESCRIPTION
This PR adds the `environment_ids` attribute to both the project resource and data source. This depends on the associated SDK PR https://github.com/skytap/skytap-sdk-go/pull/61. With this attribute, the project resource can be used to add/remove environments from the project from within terraform.

The equivalent `project_ids` field can't be added to the environment resource because, due to the order in which Terraform updates things, this won't be updated in the same `terraform apply` as the project resource which is confusing to the user. Therefore it was decided that the `environment_ids` on the project resource was a more natural way of representing things and that this should be implemented over the other.