### PR TITLE
Make routable and outbound_traffic truly optional

### DIFF
--- a/skytap/resource_skytap_environment.go
+++ b/skytap/resource_skytap_environment.go
@@ -54,7 +54,6 @@ func resourceSkytapEnvironment() *schema.Resource {
 			"outbound_traffic": {
 				Type:        schema.TypeBool,
 				Optional:    true,
-				Default:     false,
 				Description: "Indicates whether networks in the environment can send outbound traffic",
 			},
 
@@ -103,7 +102,6 @@ func resourceSkytapEnvironment() *schema.Resource {
 			"routable": {
 				Type:        schema.TypeBool,
 				Optional:    true,
-				Default:     false,
 				Description: "Indicates whether networks within the environment can route traffic to one another",
 			},
 
@@ -143,14 +141,18 @@ func resourceSkytapEnvironmentCreate(ctx context.Context, d *schema.ResourceData
 
 	templateID := d.Get("template_id").(string)
 	name := d.Get("name").(string)
-	outboundTraffic := d.Get("outbound_traffic").(bool)
-	routable := d.Get("routable").(bool)
 
 	opts := skytap.CreateEnvironmentRequest{
-		TemplateID:      &templateID,
-		Name:            &name,
-		OutboundTraffic: &outboundTraffic,
-		Routable:        &routable,
+		TemplateID: &templateID,
+		Name:       &name,
+	}
+
+	if v, ok := d.GetOk("outbound_traffic"); ok {
+		opts.OutboundTraffic = utils.Bool(v.(bool))
+	}
+
+	if v, ok := d.GetOk("routable"); ok {
+		opts.OutboundTraffic = utils.Bool(v.(bool))
 	}
 
 	if v, ok := d.GetOk("description"); ok {


### PR DESCRIPTION
@loketan @loketan-zz 
According to the [Terraform docs](https://registry.terraform.io/providers/skytap/skytap/latest/docs/resources/environment) `routable` and `outbound_traffic` are optional parameters. 

However, if they are not set by the user they will be set to false. This causes conflicts and provision errors to certain templates that have VPNs attached or have internet disabled feature set to true. 

This change seeks to align behavior associated with the REST API of creating an environment. Only required parameters are passed to the create action. Optional parameters are only passed if they are set by the user

Testing: 
With this change, I have tested against 238 templates that are currently active in our system. Out of 238 tests 238 environments were successfully provisioned and destroyed. Below are the test results of these templates 
```

```