### PR TITLE
Fixes timeout issue when disabling the internet via outbound_traffic attribute

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -28,6 +28,10 @@ builds:
   ignore:
     - goos: darwin
       goarch: '386'
+    - goos: darwin
+      goarch: arm
+    - goos: windows
+      goarch: arm64
   binary: '{{ .ProjectName }}_v{{ .Version }}'
 archives:
 - format: zip

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 ## 0.15.0 (Unreleased)
+
+## 0.14.7 (September 28, 2022)
+* `skytap_environment` : Deprecated `outbound_traffic` and introduced the new `disable_internet` as to be used instead
+* `skytap_environment` : Fixed time-out issue when using `outbound_traffic = true`
+
 ## 0.14.1 (April 17, 2020)
 
 BUG FIXES:

--- a/docs/resources/environment.md
+++ b/docs/resources/environment.md
@@ -47,7 +47,8 @@ resource "skytap_environment" "environment" {
 
 - **id** (String) The ID of this resource.
 - **label** (Block Set) Set of labels for the instance (see [below for nested schema](#nestedblock--label))
-- **outbound_traffic** (Boolean) Indicates whether networks in the environment can send outbound traffic
+- **disable_internet** (Boolean) Indicates whether networks in the environment allow outbound internet traffic
+- **outbound_traffic** (Boolean) **DEPRECATED** Indicates whether networks in the environment can send outbound traffic. Use `disable_internet` instead
 - **routable** (Boolean) Indicates whether networks within the environment can route traffic to one another
 - **shutdown_at_time** (String) The date and time that the environment will be automatically shut down. Format: yyyy/mm/dd hh:mm:ss. By default, the suspend time uses the UTC offset for the time zone defined in your user account settings. Optionally, a different UTC offset can be supplied (for example: 2018/07/20 14:20:00 -0000). The value in the API response is converted to your time zone
 - **shutdown_on_idle** (Number) The number of seconds an environment can be idle before it is automatically shut down. Valid range: 300 to 86400 seconds (5 minutes to 1 day)

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1
 	github.com/hashicorp/terraform-plugin-docs v0.4.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.5.0
-	github.com/skytap/skytap-sdk-go v0.0.0-20210602165100-9d8dca474ca4
+	github.com/skytap/skytap-sdk-go v0.0.0-20220923124913-a96c76c9c443
 	github.com/stretchr/testify v1.6.1
 )
 

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1
 	github.com/hashicorp/terraform-plugin-docs v0.4.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.5.0
-	github.com/skytap/skytap-sdk-go v0.0.0-20220923124913-a96c76c9c443
+	github.com/skytap/skytap-sdk-go v0.0.0-20220928154701-3cdf094703d6
 	github.com/stretchr/testify v1.6.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -325,8 +325,8 @@ github.com/russross/blackfriday v1.6.0/go.mod h1:ti0ldHuxg49ri4ksnFxlkCfN+hvslNl
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/sergi/go-diff v1.1.0 h1:we8PVUC3FE2uYfodKH/nBHMSetSfHDR6scGdBi+erh0=
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
-github.com/skytap/skytap-sdk-go v0.0.0-20210602165100-9d8dca474ca4 h1:4RtgZctkF7L1mdGEsN252pVK3gqWTsJKzDxzc0H4G5o=
-github.com/skytap/skytap-sdk-go v0.0.0-20210602165100-9d8dca474ca4/go.mod h1:V1HX7VGGylkRYjgyftn7vnOUZ7yOnTfwKsoZUHLkk1w=
+github.com/skytap/skytap-sdk-go v0.0.0-20220923124913-a96c76c9c443 h1:IJmrkJHv4/z/ySkLBR6/ZMQai426WP89UFGbvjVi0M4=
+github.com/skytap/skytap-sdk-go v0.0.0-20220923124913-a96c76c9c443/go.mod h1:V1HX7VGGylkRYjgyftn7vnOUZ7yOnTfwKsoZUHLkk1w=
 github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=
 github.com/spf13/pflag v1.0.2/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=

--- a/go.sum
+++ b/go.sum
@@ -325,8 +325,8 @@ github.com/russross/blackfriday v1.6.0/go.mod h1:ti0ldHuxg49ri4ksnFxlkCfN+hvslNl
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/sergi/go-diff v1.1.0 h1:we8PVUC3FE2uYfodKH/nBHMSetSfHDR6scGdBi+erh0=
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
-github.com/skytap/skytap-sdk-go v0.0.0-20220923124913-a96c76c9c443 h1:IJmrkJHv4/z/ySkLBR6/ZMQai426WP89UFGbvjVi0M4=
-github.com/skytap/skytap-sdk-go v0.0.0-20220923124913-a96c76c9c443/go.mod h1:V1HX7VGGylkRYjgyftn7vnOUZ7yOnTfwKsoZUHLkk1w=
+github.com/skytap/skytap-sdk-go v0.0.0-20220928154701-3cdf094703d6 h1:ALe1b4cL57njnx2fbLmEKty2yNIFCKz50nBnw5R3sAM=
+github.com/skytap/skytap-sdk-go v0.0.0-20220928154701-3cdf094703d6/go.mod h1:V1HX7VGGylkRYjgyftn7vnOUZ7yOnTfwKsoZUHLkk1w=
 github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=
 github.com/spf13/pflag v1.0.2/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -357,7 +357,7 @@ github.com/posener/complete/cmd/install
 github.com/posener/complete/match
 # github.com/russross/blackfriday v1.6.0
 github.com/russross/blackfriday
-# github.com/skytap/skytap-sdk-go v0.0.0-20210602165100-9d8dca474ca4
+# github.com/skytap/skytap-sdk-go v0.0.0-20220916175331-92892db63cd3 => ../skytap-sdk-go
 github.com/skytap/skytap-sdk-go/skytap
 # github.com/stretchr/testify v1.6.1
 github.com/stretchr/testify/assert

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -357,7 +357,7 @@ github.com/posener/complete/cmd/install
 github.com/posener/complete/match
 # github.com/russross/blackfriday v1.6.0
 github.com/russross/blackfriday
-# github.com/skytap/skytap-sdk-go v0.0.0-20220916175331-92892db63cd3 => ../skytap-sdk-go
+# github.com/skytap/skytap-sdk-go v0.0.0-20220928154701-3cdf094703d6
 github.com/skytap/skytap-sdk-go/skytap
 # github.com/stretchr/testify v1.6.1
 github.com/stretchr/testify/assert


### PR DESCRIPTION
This PR introduces `disable_internet` attribute to replace the `outbound_traffic` (which is now deprecated to align with Skytap V1 API)
It also includes some other fixes to avoid displaying plan differences when re-applying Terraform a second time after a `skytap_environment` was created.

This change still doesn't include stopping/suspending an environment to apply a `disable_internet`/`routable` attribute change.