### PR TITLE
Preventing VM recreation when `network_interface` is changed  

### DIFF
--- a/skytap/resource_label_category_test.go
+++ b/skytap/resource_label_category_test.go
@@ -3,7 +3,6 @@ package skytap
 import (
 	"context"
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"log"
 	"regexp"
 	"strconv"
@@ -23,9 +22,7 @@ func init() {
 }
 
 func TestAccSkytapLabelCategory_Basic(t *testing.T) {
-	uniqueSuffix := acctest.RandInt()
-
-	label := fmt.Sprintf("tftest-label-%d", uniqueSuffix)
+	label := fmt.Sprintf("tftest-label-%s", t.Name())
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
@@ -47,9 +44,7 @@ func TestAccSkytapLabelCategory_Basic(t *testing.T) {
 }
 
 func TestAccSkytapLabelCategory_Update(t *testing.T) {
-	uniqueSuffix := acctest.RandInt()
-
-	label := fmt.Sprintf("tftest-label-%d", uniqueSuffix)
+	label := fmt.Sprintf("tftest-label-%s", t.Name())
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
@@ -70,9 +65,7 @@ func TestAccSkytapLabelCategory_Update(t *testing.T) {
 }
 
 func TestAccSkytapLabelCategory_MultiValueBasic(t *testing.T) {
-	uniqueSuffix := acctest.RandInt()
-
-	label := fmt.Sprintf("tftest-label-multi-%d", uniqueSuffix)
+	label := fmt.Sprintf("tftest-label-multi-%s", t.Name())
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
@@ -94,9 +87,9 @@ func TestAccSkytapLabelCategory_MultiValueBasic(t *testing.T) {
 }
 
 func TestAccSkytapLabelCategory_Duplicated(t *testing.T) {
-	labelCategoryDuplicated := `
+	labelCategoryDuplicated := fmt.Sprintf(`
 		resource skytap_label_category "duplabel1" {
-		  name = "tftest-dup"
+		  name = "tftest-dup-%s"
 		  single_value = true
 		}
 		
@@ -104,10 +97,10 @@ func TestAccSkytapLabelCategory_Duplicated(t *testing.T) {
 		  // making sure the first category is created before trying to create the second
 		  // to avoid flakiness.
           depends_on = [skytap_label_category.duplabel1]
-		  name = "tftest-dup"
+		  name = "tftest-dup-%s"
 		  single_value = true
 		}
-	`
+	`, t.Name(), t.Name())
 	expectedError := regexp.MustCompile(".* Validation failed: Name has already been taken")
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },

--- a/skytap/resource_label_category_test.go
+++ b/skytap/resource_label_category_test.go
@@ -61,10 +61,9 @@ func TestAccSkytapLabelCategory_Update(t *testing.T) {
 				Check:  testAccCheckSkytapLabelCategoryExists("skytap_label_category.env_category"),
 			},
 			{
-				ExpectNonEmptyPlan: true,
-				Config:             testAccSkytapLabelCategory_basic(label, false),
-				Check:              testAccCheckSkytapLabelCategoryExists("skytap_label_category.env_category"),
-				ExpectError:        regexp.MustCompile(`can not be created with this single value property as it is recreated from a existing label category`),
+				Config:      testAccSkytapLabelCategory_basic(label, false),
+				Check:       testAccCheckSkytapLabelCategoryExists("skytap_label_category.env_category"),
+				ExpectError: regexp.MustCompile(`can not be created with this single value property as it is recreated from a existing label category`),
 			},
 		},
 	})

--- a/skytap/resource_skytap_environment_test.go
+++ b/skytap/resource_skytap_environment_test.go
@@ -244,15 +244,15 @@ func TestAccSkytapEnvironment_UserDataUpdate(t *testing.T) {
 	})
 }
 
-func labelRequirements(uniqueSuffix int) string {
+func labelRequirements(uniqueSuffix string) string {
 	return fmt.Sprintf(`
 		resource skytap_label_category "environment_label" {
-			name = "tftest-Environment-%d"
+			name = "tftest-Environment-%s"
 			single_value = true
 		}
 
 		resource skytap_label_category "owners_label" {
-			name = "tftest-Owners-%d"
+			name = "tftest-Owners-%s"
 			single_value = false
 		}
 	`, uniqueSuffix, uniqueSuffix)
@@ -285,7 +285,7 @@ func TestAccSkytapEnvironment_Labels(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				PreventDiskCleanup: true,
-				Config:             testAccSkytapEnvironmentConfigBlock(uniqueSuffix, templateID, labelRequirements(uniqueSuffix), labels),
+				Config:             testAccSkytapEnvironmentConfigBlock(uniqueSuffix, templateID, labelRequirements(t.Name()), labels),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSkytapEnvironmentExists("skytap_environment.foo", &environment),
 				),
@@ -325,8 +325,8 @@ func TestAccSkytapEnvironment_LabelsUpdate(t *testing.T) {
 		}
 	`
 
-	labelEnv := fmt.Sprintf("tftest-Environment-%d", uniqueSuffix)
-	labelOwners := fmt.Sprintf("tftest-Owners-%d", uniqueSuffix)
+	labelEnv := fmt.Sprintf("tftest-Environment-%s", t.Name())
+	labelOwners := fmt.Sprintf("tftest-Owners-%s", t.Name())
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
@@ -335,7 +335,7 @@ func TestAccSkytapEnvironment_LabelsUpdate(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				PreventDiskCleanup: true,
-				Config:             testAccSkytapEnvironmentConfigBlock(uniqueSuffix, templateID, labelRequirements(uniqueSuffix), labels),
+				Config:             testAccSkytapEnvironmentConfigBlock(uniqueSuffix, templateID, labelRequirements(t.Name()), labels),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSkytapEnvironmentExists("skytap_environment.foo", &environment),
 					testAccCheckSkytapEnvironmentContainsLabel(&environment, labelEnv, "Prod"),
@@ -345,7 +345,7 @@ func TestAccSkytapEnvironment_LabelsUpdate(t *testing.T) {
 			},
 			{
 				PreventDiskCleanup: true,
-				Config:             testAccSkytapEnvironmentConfigBlock(uniqueSuffix, templateID, labelRequirements(uniqueSuffix), labelsUpdated),
+				Config:             testAccSkytapEnvironmentConfigBlock(uniqueSuffix, templateID, labelRequirements(t.Name()), labelsUpdated),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSkytapEnvironmentExists("skytap_environment.foo", &environment),
 					testAccCheckSkytapEnvironmentContainsLabel(&environment, labelEnv, "UAT"),

--- a/skytap/resource_skytap_vm.go
+++ b/skytap/resource_skytap_vm.go
@@ -1119,14 +1119,15 @@ func forceRunstate(ctx context.Context, meta interface{}, environmentID string, 
 
 	opts := skytap.UpdateVMRequest{}
 	opts.Runstate = utils.VMRunstate(runstate)
-	log.Printf("[INFO] VM starting: %s", id)
-	log.Printf("[TRACE] VM starting: %v", spew.Sdump(opts))
+
+	log.Printf("[INFO] Changing VM (%s) runstate to %s", id, runstate)
+	log.Printf("[TRACE] VM (%s) update request: %v", id, spew.Sdump(opts))
 	vm, err := client.Update(ctx, environmentID, id, &opts)
 	if err != nil {
-		return fmt.Errorf("error starting VM (%s): %v", id, err)
+		return fmt.Errorf("error changing VM (%s) runstate to (%s): %v", id, runstate, err)
 	}
-	log.Printf("[INFO] started VM: %s", id)
-	log.Printf("[TRACE] started VM: %v", spew.Sdump(vm))
+	log.Printf("[INFO] VM (%s) runstate transitioned to (%s)", id, runstate)
+	log.Printf("[TRACE] VM (%s) runstate transitioned to (%s): %v", id, runstate, spew.Sdump(vm))
 	return nil
 }
 

--- a/skytap/resource_skytap_vm_test.go
+++ b/skytap/resource_skytap_vm_test.go
@@ -435,9 +435,9 @@ func TestAccSkytapVM_Typical(t *testing.T) {
 		CheckDestroy:      testAccCheckSkytapEnvironmentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:             testAccSkytapVMConfig_typical(newEnvTemplateID, templateID, vmID, uniqueSuffixEnv, 22, "", ""),
-				ExpectNonEmptyPlan: false,
+				Config: testAccSkytapVMConfig_typical(newEnvTemplateID, templateID, vmID, uniqueSuffixEnv, 22, "", ""),
 			}, {
+				PreConfig: pause(MINUTES),
 				Config: testAccSkytapVMConfig_typical(newEnvTemplateID, templateID, vmID, uniqueSuffixEnv, 23,
 					`published_service  {
 						name = "web-internal"
@@ -460,7 +460,6 @@ func TestAccSkytapVM_Typical(t *testing.T) {
         	          }
 
       	            }`),
-				ExpectNonEmptyPlan: false,
 			},
 		},
 	})

--- a/skytap/resource_skytap_vm_test.go
+++ b/skytap/resource_skytap_vm_test.go
@@ -1036,8 +1036,8 @@ func TestAccSkytapVM_Labels(t *testing.T) {
 		}
 	`
 
-	labelEnv := fmt.Sprintf("tftest-Environment-%d", uniqueSuffixEnv)
-	labelOwners := fmt.Sprintf("tftest-Owners-%d", uniqueSuffixEnv)
+	labelEnv := fmt.Sprintf("tftest-Environment-%s", t.Name())
+	labelOwners := fmt.Sprintf("tftest-Owners-%s", t.Name())
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
@@ -1046,7 +1046,7 @@ func TestAccSkytapVM_Labels(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccSkytapVMConfigBlock(newEnvTemplateID, uniqueSuffixEnv, templateID, vmID, "test",
-					labelRequirements(uniqueSuffixEnv), labels),
+					labelRequirements(t.Name()), labels),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSkytapVMExists("skytap_environment.foo", "skytap_vm.bar", &vm),
 					resource.TestCheckResourceAttr("skytap_vm.bar", "name", "test"),
@@ -1058,7 +1058,7 @@ func TestAccSkytapVM_Labels(t *testing.T) {
 			},
 			{
 				Config: testAccSkytapVMConfigBlock(newEnvTemplateID, uniqueSuffixEnv, templateID, vmID, "test",
-					labelRequirements(uniqueSuffixEnv), labelsUpdated),
+					labelRequirements(t.Name()), labelsUpdated),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSkytapVMExists("skytap_environment.foo", "skytap_vm.bar", &vm),
 					resource.TestCheckResourceAttr("skytap_vm.bar", "name", "test"),

--- a/skytap/resource_skytap_vm_test.go
+++ b/skytap/resource_skytap_vm_test.go
@@ -170,6 +170,7 @@ func TestAccSkytapVM_Interface(t *testing.T) {
 					testAccCheckSkytapInterfaceAttributes(t, "skytap_environment.foo", "skytap_network.baz", &vm, skytap.NICTypeVMXNet3, []string{"192.168.0.10", "192.168.0.11"}, []string{"bloggs-web", "bloggs-web2"}),
 				),
 			}, {
+				PreConfig: pause(MINUTES),
 				Config: testAccSkytapVMConfig_basic(newEnvTemplateID, uniqueSuffixEnv, `
 					resource "skytap_network" "baz" {
   						name        		= "tftest-network-1"
@@ -200,6 +201,7 @@ func TestAccSkytapVM_Interface(t *testing.T) {
 					testAccCheckSkytapInterfaceAttributes(t, "skytap_environment.foo", "skytap_network.baz", &vm, skytap.NICTypeVMXNet3, []string{"192.168.0.20", "192.168.0.21"}, []string{"bloggs-web3", "bloggs-web4"}),
 				),
 			}, {
+				PreConfig: pause(MINUTES),
 				Config: testAccSkytapVMConfig_basic(newEnvTemplateID, uniqueSuffixEnv, `
 					resource "skytap_network" "baz" {
   						name        		= "tftest-network-1"
@@ -265,6 +267,7 @@ func TestAccSkytapVM_PublishedService(t *testing.T) {
 					testAccCheckSkytapPublishedServiceAttributes(&vm, []int{8080, 8081}),
 				),
 			}, {
+				PreConfig: pause(MINUTES),
 				Config: testAccSkytapVMConfig_basic(newEnvTemplateID, uniqueSuffixEnv, `
 					resource "skytap_network" "baz" {
   						name        		= "tftest-network-1"
@@ -294,6 +297,7 @@ func TestAccSkytapVM_PublishedService(t *testing.T) {
 					testAccCheckSkytapPublishedServiceAttributes(&vm, []int{8082, 8083}),
 				),
 			}, {
+				PreConfig: pause(MINUTES),
 				Config: testAccSkytapVMConfig_basic(newEnvTemplateID, uniqueSuffixEnv, `
 					resource "skytap_network" "baz" {
   						name        		= "tftest-network-1"
@@ -319,6 +323,7 @@ func TestAccSkytapVM_PublishedService(t *testing.T) {
 					testAccCheckSkytapPublishedServiceAttributes(&vm, []int{8084}),
 				),
 			}, {
+				PreConfig: pause(MINUTES),
 				Config: testAccSkytapVMConfig_basic(newEnvTemplateID, uniqueSuffixEnv, `
 					resource "skytap_network" "baz" {
   						name        		= "tftest-network-1"


### PR DESCRIPTION
This PR removes the `ForceNew` from the `network_interface` to avoid recreating the VM on changes.
