### PR TITLE
updated range for vm cpus to 1,24

### DIFF
--- a/skytap/resource_skytap_vm.go
+++ b/skytap/resource_skytap_vm.go
@@ -67,7 +67,7 @@ func resourceSkytapVM() *schema.Resource {
 				Optional:     true,
 				Computed:     true,
 				Description:  "Number of CPUs allocated to this virtual machine",
-				ValidateFunc: validation.IntBetween(1, 12),
+				ValidateFunc: validation.IntBetween(1, 24),
 			},
 
 			"max_cpus": {


### PR DESCRIPTION
The default range for cpus is limited to 1 - 12. I've updated this to use 1 - 24 that falls in line with the max vCPUs available in currently deployed regions. (see https://help.skytap.com/overview-service-limits.html)